### PR TITLE
(FEAT) - Add tilde SASS Support, Documentation Fix

### DIFF
--- a/.core/gulp.tasks.js
+++ b/.core/gulp.tasks.js
@@ -12,6 +12,7 @@ const gulpwatch = require('gulp-watch');
 const run = require('gulp-run');
 const prefix = require('gulp-autoprefixer');
 const sass = require('gulp-sass');
+const tildeImporter = require('node-sass-tilde-importer');
 const less = require('gulp-less');
 const csso = require('gulp-csso');
 const sourcemaps = require('gulp-sourcemaps');
@@ -50,8 +51,8 @@ const reactium = (gulp, config, webpackConfig) => {
             rootPath,
             `${config.dest.dist}/${ePathRelative.replace(
                 /^.*?\/assets/,
-                'assets'
-            )}`
+                'assets',
+            )}`,
         );
 
         let displaySrc = path.relative(rootPath, e.path);
@@ -73,7 +74,7 @@ const reactium = (gulp, config, webpackConfig) => {
         }
 
         console.log(
-            `${timestamp()} File ${e.event}: ${displaySrc} -> ${displayDest}`
+            `${timestamp()} File ${e.event}: ${displaySrc} -> ${displayDest}`,
         );
     };
 
@@ -124,11 +125,11 @@ const reactium = (gulp, config, webpackConfig) => {
         local: () => {
             let watch = new run.Command(
                 'cross-env SSR_MODE=off NODE_ENV=development gulp',
-                { verbosity: 3 }
+                { verbosity: 3 },
             );
             let babel = new run.Command(
                 'cross-env SSR_MODE=off NODE_ENV=development nodemon ./.core/index.js --exec babel-node',
-                { verbosity: 3 }
+                { verbosity: 3 },
             );
 
             watch.exec();
@@ -137,11 +138,11 @@ const reactium = (gulp, config, webpackConfig) => {
         'local:ssr': () => {
             let watch = new run.Command(
                 'cross-env SSR_MODE=on NODE_ENV=development gulp',
-                { verbosity: 3 }
+                { verbosity: 3 },
             );
             let babel = new run.Command(
                 'cross-env SSR_MODE=on NODE_ENV=development nodemon ./.core/index.js --exec babel-node',
-                { verbosity: 3 }
+                { verbosity: 3 },
             );
 
             watch.exec();
@@ -165,7 +166,7 @@ const reactium = (gulp, config, webpackConfig) => {
                 ['scripts', 'assets', 'styles'],
                 ['markup', 'json'],
                 ['postBuild'],
-                done
+                done,
             );
         },
         // stub task to provide sequenced override for application
@@ -246,7 +247,7 @@ const reactium = (gulp, config, webpackConfig) => {
             fs.copySync(config.dest.dist, config.dest.static);
 
             let mainPage = path.normalize(
-                `${config.dest.static}/index-static.html`
+                `${config.dest.static}/index-static.html`,
             );
 
             if (fs.existsSync(mainPage)) {
@@ -286,7 +287,7 @@ const reactium = (gulp, config, webpackConfig) => {
 
                     colorFileContents += colorVars.join('\n') + '\n\n\n';
                     colorFileContents += `$color: (\n${colorArr.join(
-                        ',\n'
+                        ',\n',
                     )}\n);\n\n\n`;
                     colorFileContents +=
                         '@each $clr-name, $clr-code in $color {\n\t.#{$clr-name} { color: $clr-code; }\n\t.bg-#{$clr-name} { background-color: $clr-code; }\n}';
@@ -295,7 +296,7 @@ const reactium = (gulp, config, webpackConfig) => {
                     fs.writeFileSync(
                         config.dest.colors,
                         colorFileContents,
-                        'utf8'
+                        'utf8',
                     );
                 }
             }
@@ -314,11 +315,11 @@ const reactium = (gulp, config, webpackConfig) => {
                 .pipe(
                     gulpif(
                         isSass,
-                        sass({ includePaths: config.src.includes }).on(
-                            'error',
-                            sass.logError
-                        )
-                    )
+                        sass({
+                            importer: tildeImporter,
+                            includePaths: config.src.includes,
+                        }).on('error', sass.logError),
+                    ),
                 )
                 .pipe(gulpif(isLess, less({ paths: config.src.includes })))
                 .pipe(prefix(config.browsers))

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -12,6 +12,7 @@ $ npm i -g atomic-reactor-cli
 ```
 
 ## Zero Day Install
+
 Instead of cloning the main Reactium repo, you can install via the ARCLI:
 
 ```
@@ -20,8 +21,6 @@ $ arcli reactium install
 $ npm install
 $ npm run local
 ```
-
-
 
 ## Components
 
@@ -388,13 +387,12 @@ export default {
 In your actions.js file you would do something like:
 
 ```javascript
-import { actionTypes } from 'dependencies';
 import deps from 'dependencies';
 
 export default {
     mount: params => dispatch => {
         deps.services.Test.fetchHello().then(data => {
-            dispatch({ type: actionTypes.TEST_MOUNT, payload: data });
+            dispatch({ type: deps.actionTypes.TEST_MOUNT, payload: data });
         });
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
             "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.1.5.tgz",
             "integrity": "sha512-zbO/DtTnaDappBflIU3zYEgATLToRDmW5uN/EGH1GXaes7ydfjqmAoK++xmJIA+8HfDw7UyPZNdM8fhGhfmMhw==",
             "requires": {
-                "chokidar": "^2.0.3",
-                "commander": "^2.8.1",
-                "convert-source-map": "^1.1.0",
-                "fs-readdir-recursive": "^1.1.0",
-                "glob": "^7.0.0",
-                "lodash": "^4.17.10",
-                "mkdirp": "^0.5.1",
-                "output-file-sync": "^2.0.0",
-                "slash": "^2.0.0",
-                "source-map": "^0.5.0"
+                "chokidar": "2.0.4",
+                "commander": "2.19.0",
+                "convert-source-map": "1.6.0",
+                "fs-readdir-recursive": "1.1.0",
+                "glob": "7.1.3",
+                "lodash": "4.17.11",
+                "mkdirp": "0.5.1",
+                "output-file-sync": "2.0.1",
+                "slash": "2.0.0",
+                "source-map": "0.5.7"
             }
         },
         "@babel/code-frame": {
@@ -27,7 +27,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/core": {
@@ -36,20 +36,20 @@
             "integrity": "sha512-vOyH020C56tQvte++i+rX2yokZcRfbv/kKcw+/BCRw/cK6dvsr47aCzm8oC1XHwMSEWbqrZKzZRLzLnq6SFMsg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.1.5",
-                "@babel/helpers": "^7.1.5",
-                "@babel/parser": "^7.1.5",
-                "@babel/template": "^7.1.2",
-                "@babel/traverse": "^7.1.5",
-                "@babel/types": "^7.1.5",
-                "convert-source-map": "^1.1.0",
-                "debug": "^3.1.0",
-                "json5": "^0.5.0",
-                "lodash": "^4.17.10",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.1.5",
+                "@babel/helpers": "7.1.5",
+                "@babel/parser": "7.1.5",
+                "@babel/template": "7.1.2",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5",
+                "convert-source-map": "1.6.0",
+                "debug": "3.2.6",
+                "json5": "0.5.1",
+                "lodash": "4.17.11",
+                "resolve": "1.8.1",
+                "semver": "5.6.0",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "debug": {
@@ -58,7 +58,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -75,11 +75,11 @@
             "integrity": "sha512-IO31r62xfMI+wBJVmgx0JR9ZOHty8HkoYpQAjRWUGG9vykBTlGHdArZ8zoFtpUu2gs17K7qTl/TtPpiSi6t+MA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.1.5",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.1.5",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             }
         },
         "@babel/helper-annotate-as-pure": {
@@ -88,7 +88,7 @@
             "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -97,8 +97,8 @@
             "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-explode-assignable-expression": "7.1.0",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -107,8 +107,8 @@
             "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0",
-                "esutils": "^2.0.0"
+                "@babel/types": "7.1.5",
+                "esutils": "2.0.2"
             }
         },
         "@babel/helper-call-delegate": {
@@ -117,9 +117,9 @@
             "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.0.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-hoist-variables": "7.0.0",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-define-map": {
@@ -128,9 +128,9 @@
             "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/types": "7.1.5",
+                "lodash": "4.17.11"
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -139,8 +139,8 @@
             "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-function-name": {
@@ -149,9 +149,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.1.2",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -160,7 +160,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -169,7 +169,7 @@
             "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -178,7 +178,7 @@
             "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-module-imports": {
@@ -187,7 +187,7 @@
             "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-module-transforms": {
@@ -196,12 +196,12 @@
             "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/template": "7.1.2",
+                "@babel/types": "7.1.5",
+                "lodash": "4.17.11"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -210,7 +210,7 @@
             "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -225,7 +225,7 @@
             "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.11"
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -234,11 +234,11 @@
             "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-wrap-function": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-wrap-function": "7.1.0",
+                "@babel/template": "7.1.2",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-replace-supers": {
@@ -247,10 +247,10 @@
             "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.0.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-member-expression-to-functions": "7.0.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-simple-access": {
@@ -259,8 +259,8 @@
             "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/template": "7.1.2",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -269,7 +269,7 @@
             "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helper-wrap-function": {
@@ -278,10 +278,10 @@
             "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/template": "7.1.2",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/helpers": {
@@ -290,9 +290,9 @@
             "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.2",
-                "@babel/traverse": "^7.1.5",
-                "@babel/types": "^7.1.5"
+                "@babel/template": "7.1.2",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/highlight": {
@@ -301,9 +301,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             }
         },
         "@babel/node": {
@@ -311,13 +311,13 @@
             "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.0.0.tgz",
             "integrity": "sha512-mKbN8Bb1TzH9YnKMWMhBRX+o5MVJHtUSalNcsiGa4FRgVfY7ozqkbttuIDWqeXxZ3rwI9ZqmCUr9XsPV2VYlSw==",
             "requires": {
-                "@babel/polyfill": "^7.0.0",
-                "@babel/register": "^7.0.0",
-                "commander": "^2.8.1",
-                "fs-readdir-recursive": "^1.0.0",
-                "lodash": "^4.17.10",
-                "output-file-sync": "^2.0.0",
-                "v8flags": "^3.1.1"
+                "@babel/polyfill": "7.0.0",
+                "@babel/register": "7.0.0",
+                "commander": "2.19.0",
+                "fs-readdir-recursive": "1.1.0",
+                "lodash": "4.17.11",
+                "output-file-sync": "2.0.1",
+                "v8flags": "3.1.1"
             }
         },
         "@babel/parser": {
@@ -332,9 +332,9 @@
             "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0",
-                "@babel/plugin-syntax-async-generators": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0",
+                "@babel/plugin-syntax-async-generators": "7.0.0"
             }
         },
         "@babel/plugin-proposal-class-properties": {
@@ -343,12 +343,12 @@
             "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-member-expression-to-functions": "^7.0.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.1.0",
-                "@babel/plugin-syntax-class-properties": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-member-expression-to-functions": "7.0.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.1.0",
+                "@babel/plugin-syntax-class-properties": "7.0.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -357,8 +357,8 @@
             "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-json-strings": "7.0.0"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -367,8 +367,8 @@
             "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.0.0"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -377,8 +377,8 @@
             "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
@@ -387,9 +387,9 @@
             "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -398,7 +398,7 @@
             "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-class-properties": {
@@ -407,7 +407,7 @@
             "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -416,7 +416,7 @@
             "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
@@ -425,7 +425,7 @@
             "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -434,7 +434,7 @@
             "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
@@ -443,7 +443,7 @@
             "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -452,7 +452,7 @@
             "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
@@ -461,9 +461,9 @@
             "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
@@ -472,7 +472,7 @@
             "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-block-scoping": {
@@ -481,8 +481,8 @@
             "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "lodash": "4.17.11"
             }
         },
         "@babel/plugin-transform-classes": {
@@ -491,14 +491,14 @@
             "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-define-map": "^7.1.0",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-define-map": "7.1.0",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "globals": "11.9.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
@@ -507,7 +507,7 @@
             "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
@@ -516,7 +516,7 @@
             "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
@@ -525,9 +525,9 @@
             "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.1.3"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -536,7 +536,7 @@
             "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
@@ -545,8 +545,8 @@
             "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -555,7 +555,7 @@
             "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
@@ -564,8 +564,8 @@
             "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-literals": {
@@ -574,7 +574,7 @@
             "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-amd": {
@@ -583,8 +583,8 @@
             "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
@@ -593,9 +593,9 @@
             "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -604,8 +604,8 @@
             "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-hoist-variables": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
@@ -614,8 +614,8 @@
             "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -624,7 +624,7 @@
             "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-object-super": {
@@ -633,8 +633,8 @@
             "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.1.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.1.0"
             }
         },
         "@babel/plugin-transform-parameters": {
@@ -643,9 +643,9 @@
             "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.1.0",
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-call-delegate": "7.1.0",
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -654,7 +654,7 @@
             "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
@@ -663,9 +663,9 @@
             "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-builder-react-jsx": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
@@ -674,8 +674,8 @@
             "integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
@@ -684,8 +684,8 @@
             "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-regenerator": {
@@ -694,7 +694,7 @@
             "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
             "dev": true,
             "requires": {
-                "regenerator-transform": "^0.13.3"
+                "regenerator-transform": "0.13.3"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -703,7 +703,7 @@
             "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-spread": {
@@ -712,7 +712,7 @@
             "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -721,8 +721,8 @@
             "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0"
             }
         },
         "@babel/plugin-transform-template-literals": {
@@ -731,8 +731,8 @@
             "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
@@ -741,7 +741,7 @@
             "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -750,9 +750,9 @@
             "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.1.3"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/polyfill": {
@@ -760,8 +760,8 @@
             "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
             "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
             "requires": {
-                "core-js": "^2.5.7",
-                "regenerator-runtime": "^0.11.1"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "@babel/preset-env": {
@@ -770,47 +770,47 @@
             "integrity": "sha512-pQ+2o0YyCp98XG0ODOHJd9z4GsSoV5jicSedRwCrU8uiqcJahwQiOq0asSZEb/m/lwyu6X5INvH/DSiwnQKncw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-                "@babel/plugin-proposal-json-strings": "^7.0.0",
-                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-                "@babel/plugin-syntax-async-generators": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-                "@babel/plugin-transform-arrow-functions": "^7.0.0",
-                "@babel/plugin-transform-async-to-generator": "^7.1.0",
-                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-                "@babel/plugin-transform-block-scoping": "^7.1.5",
-                "@babel/plugin-transform-classes": "^7.1.0",
-                "@babel/plugin-transform-computed-properties": "^7.0.0",
-                "@babel/plugin-transform-destructuring": "^7.0.0",
-                "@babel/plugin-transform-dotall-regex": "^7.0.0",
-                "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-                "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-                "@babel/plugin-transform-for-of": "^7.0.0",
-                "@babel/plugin-transform-function-name": "^7.1.0",
-                "@babel/plugin-transform-literals": "^7.0.0",
-                "@babel/plugin-transform-modules-amd": "^7.1.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-                "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-                "@babel/plugin-transform-modules-umd": "^7.1.0",
-                "@babel/plugin-transform-new-target": "^7.0.0",
-                "@babel/plugin-transform-object-super": "^7.1.0",
-                "@babel/plugin-transform-parameters": "^7.1.0",
-                "@babel/plugin-transform-regenerator": "^7.0.0",
-                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-                "@babel/plugin-transform-spread": "^7.0.0",
-                "@babel/plugin-transform-sticky-regex": "^7.0.0",
-                "@babel/plugin-transform-template-literals": "^7.0.0",
-                "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-                "@babel/plugin-transform-unicode-regex": "^7.0.0",
-                "browserslist": "^4.1.0",
-                "invariant": "^2.2.2",
-                "js-levenshtein": "^1.1.3",
-                "semver": "^5.3.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "7.1.0",
+                "@babel/plugin-proposal-json-strings": "7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+                "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+                "@babel/plugin-syntax-async-generators": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+                "@babel/plugin-transform-arrow-functions": "7.0.0",
+                "@babel/plugin-transform-async-to-generator": "7.1.0",
+                "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+                "@babel/plugin-transform-block-scoping": "7.1.5",
+                "@babel/plugin-transform-classes": "7.1.0",
+                "@babel/plugin-transform-computed-properties": "7.0.0",
+                "@babel/plugin-transform-destructuring": "7.1.3",
+                "@babel/plugin-transform-dotall-regex": "7.0.0",
+                "@babel/plugin-transform-duplicate-keys": "7.0.0",
+                "@babel/plugin-transform-exponentiation-operator": "7.1.0",
+                "@babel/plugin-transform-for-of": "7.0.0",
+                "@babel/plugin-transform-function-name": "7.1.0",
+                "@babel/plugin-transform-literals": "7.0.0",
+                "@babel/plugin-transform-modules-amd": "7.1.0",
+                "@babel/plugin-transform-modules-commonjs": "7.1.0",
+                "@babel/plugin-transform-modules-systemjs": "7.1.3",
+                "@babel/plugin-transform-modules-umd": "7.1.0",
+                "@babel/plugin-transform-new-target": "7.0.0",
+                "@babel/plugin-transform-object-super": "7.1.0",
+                "@babel/plugin-transform-parameters": "7.1.0",
+                "@babel/plugin-transform-regenerator": "7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "7.0.0",
+                "@babel/plugin-transform-spread": "7.0.0",
+                "@babel/plugin-transform-sticky-regex": "7.0.0",
+                "@babel/plugin-transform-template-literals": "7.0.0",
+                "@babel/plugin-transform-typeof-symbol": "7.0.0",
+                "@babel/plugin-transform-unicode-regex": "7.0.0",
+                "browserslist": "4.3.4",
+                "invariant": "2.2.4",
+                "js-levenshtein": "1.1.4",
+                "semver": "5.6.0"
             }
         },
         "@babel/preset-react": {
@@ -819,11 +819,11 @@
             "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-transform-react-display-name": "^7.0.0",
-                "@babel/plugin-transform-react-jsx": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-transform-react-display-name": "7.0.0",
+                "@babel/plugin-transform-react-jsx": "7.0.0",
+                "@babel/plugin-transform-react-jsx-self": "7.0.0",
+                "@babel/plugin-transform-react-jsx-source": "7.0.0"
             }
         },
         "@babel/register": {
@@ -831,13 +831,13 @@
             "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
             "integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
             "requires": {
-                "core-js": "^2.5.7",
-                "find-cache-dir": "^1.0.0",
-                "home-or-tmp": "^3.0.0",
-                "lodash": "^4.17.10",
-                "mkdirp": "^0.5.1",
-                "pirates": "^4.0.0",
-                "source-map-support": "^0.5.9"
+                "core-js": "2.5.7",
+                "find-cache-dir": "1.0.0",
+                "home-or-tmp": "3.0.0",
+                "lodash": "4.17.11",
+                "mkdirp": "0.5.1",
+                "pirates": "4.0.0",
+                "source-map-support": "0.5.9"
             }
         },
         "@babel/runtime": {
@@ -845,7 +845,7 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
             "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
             "requires": {
-                "regenerator-runtime": "^0.12.0"
+                "regenerator-runtime": "0.12.1"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -861,9 +861,9 @@
             "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.1.2",
-                "@babel/types": "^7.1.2"
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.1.5",
+                "@babel/types": "7.1.5"
             }
         },
         "@babel/traverse": {
@@ -872,15 +872,15 @@
             "integrity": "sha512-eU6XokWypl0MVJo+MTSPUtlfPePkrqsF26O+l1qFGlCKWwmiYAYy2Sy44Qw8m2u/LbPCsxYt90rghmqhYMGpPA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.1.5",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.1.5",
-                "@babel/types": "^7.1.5",
-                "debug": "^3.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.10"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.1.5",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/parser": "7.1.5",
+                "@babel/types": "7.1.5",
+                "debug": "3.2.6",
+                "globals": "11.9.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "debug": {
@@ -889,7 +889,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -906,9 +906,9 @@
             "integrity": "sha512-sJeqa/d9eM/bax8Ivg+fXF7FpN3E/ZmTrWbkk6r+g7biVYfALMnLin4dKijsaqEhpd2xvOGfQTkQkD31YCVV4A==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "2.0.0"
             }
         },
         "@gulp-sourcemaps/identity-map": {
@@ -917,11 +917,11 @@
             "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.3",
-                "css": "^2.2.1",
-                "normalize-path": "^2.1.1",
-                "source-map": "^0.6.0",
-                "through2": "^2.0.3"
+                "acorn": "5.7.3",
+                "css": "2.2.4",
+                "normalize-path": "2.1.1",
+                "source-map": "0.6.1",
+                "through2": "2.0.5"
             },
             "dependencies": {
                 "source-map": {
@@ -938,8 +938,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "^2.0.1",
-                "through2": "^2.0.3"
+                "normalize-path": "2.1.1",
+                "through2": "2.0.5"
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -947,8 +947,8 @@
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
             "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
             "requires": {
-                "call-me-maybe": "^1.0.1",
-                "glob-to-regexp": "^0.3.0"
+                "call-me-maybe": "1.0.1",
+                "glob-to-regexp": "0.3.0"
             }
         },
         "@nodelib/fs.stat": {
@@ -962,7 +962,7 @@
             "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
             "dev": true,
             "requires": {
-                "any-observable": "^0.3.0"
+                "any-observable": "0.3.0"
             }
         },
         "@types/node": {
@@ -1049,7 +1049,7 @@
             "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
             "dev": true,
             "requires": {
-                "@xtuc/ieee754": "^1.2.0"
+                "@xtuc/ieee754": "1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1169,7 +1169,7 @@
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "requires": {
-                "mime-types": "~2.1.18",
+                "mime-types": "2.1.21",
                 "negotiator": "0.6.1"
             }
         },
@@ -1179,20 +1179,20 @@
             "integrity": "sha512-3OOR92FTc2p5/EcOzPcXp+Cbo+3C15nV9RXHlOUBCBpHhcB+0frbSNR9ehED/o7sTcyGVtqGJpguToEdlXhD0w==",
             "dev": true,
             "requires": {
-                "convert-source-map": "^1.5.0",
-                "glob": "^7.0.5",
-                "indx": "^0.2.3",
-                "lodash.clone": "^4.3.2",
-                "lodash.defaults": "^4.0.1",
-                "lodash.flatten": "^4.2.0",
-                "lodash.merge": "^4.4.0",
-                "lodash.partialright": "^4.1.4",
-                "lodash.pick": "^4.2.1",
-                "lodash.uniq": "^4.3.0",
-                "resolve": "^1.5.0",
-                "semver": "^5.3.0",
-                "uglify-js": "^2.8.22",
-                "when": "^3.7.8"
+                "convert-source-map": "1.6.0",
+                "glob": "7.1.3",
+                "indx": "0.2.3",
+                "lodash.clone": "4.5.0",
+                "lodash.defaults": "4.2.0",
+                "lodash.flatten": "4.4.0",
+                "lodash.merge": "4.6.1",
+                "lodash.partialright": "4.2.1",
+                "lodash.pick": "4.4.0",
+                "lodash.uniq": "4.5.0",
+                "resolve": "1.8.1",
+                "semver": "5.6.0",
+                "uglify-js": "2.8.29",
+                "when": "3.7.8"
             },
             "dependencies": {
                 "camelcase": {
@@ -1207,8 +1207,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -1224,9 +1224,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
                     }
                 },
                 "window-size": {
@@ -1247,9 +1247,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -1267,14 +1267,8 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0"
+                "acorn": "5.7.3"
             }
-        },
-        "acorn-jsx": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-            "dev": true
         },
         "action-sequence": {
             "version": "1.0.3",
@@ -1293,10 +1287,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
             "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "ajv-keywords": {
@@ -1311,9 +1305,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -1322,7 +1316,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1339,7 +1333,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "^2.0.0"
+                "string-width": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1360,8 +1354,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -1370,7 +1364,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -1381,7 +1375,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "^0.1.0"
+                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-cyan": {
@@ -1433,7 +1427,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.3"
             }
         },
         "ansi-wrap": {
@@ -1453,8 +1447,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             }
         },
         "apache-crypt": {
@@ -1462,7 +1456,7 @@
             "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.1.tgz",
             "integrity": "sha1-1vxyqm0n2ZyVqU/RiNcx7v/6Zjw=",
             "requires": {
-                "unix-crypt-td-js": "^1.0.0"
+                "unix-crypt-td-js": "1.0.0"
             }
         },
         "apache-md5": {
@@ -1482,13 +1476,13 @@
             "integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
             "dev": true,
             "requires": {
-                "archiver-utils": "^2.0.0",
-                "async": "^2.0.0",
-                "buffer-crc32": "^0.2.1",
-                "glob": "^7.0.0",
-                "readable-stream": "^2.0.0",
-                "tar-stream": "^1.5.0",
-                "zip-stream": "^2.0.1"
+                "archiver-utils": "2.0.0",
+                "async": "2.6.1",
+                "buffer-crc32": "0.2.13",
+                "glob": "7.1.3",
+                "readable-stream": "2.3.6",
+                "tar-stream": "1.6.2",
+                "zip-stream": "2.0.1"
             }
         },
         "archiver-utils": {
@@ -1497,18 +1491,18 @@
             "integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "graceful-fs": "^4.1.0",
-                "lazystream": "^1.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.toarray": "^4.4.0",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.15",
+                "lazystream": "1.0.0",
+                "lodash.assign": "4.2.0",
+                "lodash.defaults": "4.2.0",
+                "lodash.difference": "4.5.0",
+                "lodash.flatten": "4.4.0",
+                "lodash.isplainobject": "4.0.6",
+                "lodash.toarray": "4.4.0",
+                "lodash.union": "4.6.0",
+                "normalize-path": "3.0.0",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "normalize-path": {
@@ -1531,8 +1525,8 @@
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
             "dev": true,
             "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "argparse": {
@@ -1541,7 +1535,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -1593,8 +1587,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.7.0"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.12.0"
             }
         },
         "array-map": {
@@ -1618,7 +1612,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -1652,7 +1646,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "asn1.js": {
@@ -1661,9 +1655,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "assert": {
@@ -1702,19 +1696,13 @@
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
-        "astral-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-            "dev": true
-        },
         "async": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
             "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.11"
             }
         },
         "async-each": {
@@ -1755,27 +1743,27 @@
             "integrity": "sha512-uxRN3PvHlD+7lHwHQhhxIfW2K+Xy6+BEDJdO0tCuW1a3IYxFu0P7nJWLdsJdEAe2IvAe8B2z8VyYJJzmE341ag==",
             "dev": true,
             "requires": {
-                "action-sequence": "^1.0.3",
-                "camelcase": "^5.0.0",
-                "chalk": "^1.1.3",
-                "cli-spinners": "^1.0.0",
-                "commander": "^2.16.0",
-                "decamelize": "^2.0.0",
-                "decompress": "^4.2.0",
-                "folder-zipper": "^1.0.0",
-                "fs-extra": "^2.1.2",
-                "fs-readdir-recursive": "^1.1.0",
-                "globby": "^8.0.1",
-                "handlebars": "^4.0.11",
-                "moment": "^2.18.1",
-                "object-path": "^0.11.4",
-                "ora": "^1.2.0",
-                "prettier": "^1.14.3",
-                "prompt": "^1.0.0",
-                "request": "^2.88.0",
-                "semver": "^5.6.0",
-                "slugify": "^1.1.0",
-                "underscore": "^1.9.1"
+                "action-sequence": "1.0.3",
+                "camelcase": "5.0.0",
+                "chalk": "1.1.3",
+                "cli-spinners": "1.3.1",
+                "commander": "2.19.0",
+                "decamelize": "2.0.0",
+                "decompress": "4.2.0",
+                "folder-zipper": "1.0.0",
+                "fs-extra": "2.1.2",
+                "fs-readdir-recursive": "1.1.0",
+                "globby": "8.0.1",
+                "handlebars": "4.0.12",
+                "moment": "2.22.2",
+                "object-path": "0.11.4",
+                "ora": "1.4.0",
+                "prettier": "1.15.2",
+                "prompt": "1.0.0",
+                "request": "2.88.0",
+                "semver": "5.6.0",
+                "slugify": "1.3.3",
+                "underscore": "1.9.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1790,11 +1778,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "fs-extra": {
@@ -1803,8 +1791,8 @@
                     "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0"
+                        "graceful-fs": "4.1.15",
+                        "jsonfile": "2.4.0"
                     }
                 },
                 "jsonfile": {
@@ -1813,7 +1801,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "graceful-fs": "4.1.15"
                     }
                 },
                 "ora": {
@@ -1822,10 +1810,10 @@
                     "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.1.0",
-                        "cli-cursor": "^2.1.0",
-                        "cli-spinners": "^1.0.1",
-                        "log-symbols": "^2.1.0"
+                        "chalk": "2.4.1",
+                        "cli-cursor": "2.1.0",
+                        "cli-spinners": "1.3.1",
+                        "log-symbols": "2.2.0"
                     },
                     "dependencies": {
                         "ansi-styles": {
@@ -1834,7 +1822,7 @@
                             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                             "dev": true,
                             "requires": {
-                                "color-convert": "^1.9.0"
+                                "color-convert": "1.9.3"
                             }
                         },
                         "chalk": {
@@ -1843,9 +1831,9 @@
                             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                             "dev": true,
                             "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
+                                "ansi-styles": "3.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "5.5.0"
                             }
                         },
                         "supports-color": {
@@ -1854,7 +1842,7 @@
                             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -1873,12 +1861,12 @@
             "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
             "dev": true,
             "requires": {
-                "browserslist": "^3.2.8",
-                "caniuse-lite": "^1.0.30000864",
-                "normalize-range": "^0.1.2",
-                "num2fraction": "^1.2.2",
-                "postcss": "^6.0.23",
-                "postcss-value-parser": "^3.2.3"
+                "browserslist": "3.2.8",
+                "caniuse-lite": "1.0.30000907",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "6.0.23",
+                "postcss-value-parser": "3.3.1"
             },
             "dependencies": {
                 "browserslist": {
@@ -1887,8 +1875,8 @@
                     "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "^1.0.30000844",
-                        "electron-to-chromium": "^1.3.47"
+                        "caniuse-lite": "1.0.30000907",
+                        "electron-to-chromium": "1.3.84"
                     }
                 }
             }
@@ -1908,8 +1896,8 @@
             "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
             "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
             "requires": {
-                "follow-redirects": "^1.3.0",
-                "is-buffer": "^1.1.5"
+                "follow-redirects": "1.5.9",
+                "is-buffer": "1.1.6"
             }
         },
         "babel-eslint": {
@@ -1918,12 +1906,12 @@
             "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.0.0",
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.1.5",
+                "@babel/traverse": "7.1.5",
+                "@babel/types": "7.1.5",
                 "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
+                "eslint-visitor-keys": "1.0.0"
             },
             "dependencies": {
                 "eslint-scope": {
@@ -1932,8 +1920,8 @@
                     "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
                     "dev": true,
                     "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
+                        "esrecurse": "4.2.1",
+                        "estraverse": "4.2.0"
                     }
                 }
             }
@@ -1944,10 +1932,10 @@
             "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "^1.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "util.promisify": "^1.0.0"
+                "find-cache-dir": "1.0.0",
+                "loader-utils": "1.1.0",
+                "mkdirp": "0.5.1",
+                "util.promisify": "1.0.0"
             }
         },
         "babel-plugin-module-resolver": {
@@ -1956,11 +1944,11 @@
             "integrity": "sha512-1Q77Al4ydp6nYApJ7sQ2fmgz30WuQgJZegIYuyOdbdpxenB/bSezQ3hDPsumIXGlUS4vUIv+EwFjzzXZNWtARw==",
             "dev": true,
             "requires": {
-                "find-babel-config": "^1.1.0",
-                "glob": "^7.1.2",
-                "pkg-up": "^2.0.0",
-                "reselect": "^3.0.1",
-                "resolve": "^1.4.0"
+                "find-babel-config": "1.1.0",
+                "glob": "7.1.3",
+                "pkg-up": "2.0.0",
+                "reselect": "3.0.1",
+                "resolve": "1.8.1"
             }
         },
         "babel-runtime": {
@@ -1968,8 +1956,8 @@
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "backo2": {
@@ -1988,13 +1976,13 @@
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2002,7 +1990,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2010,7 +1998,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -2018,7 +2006,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -2026,9 +2014,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -2075,7 +2063,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "bcryptjs": {
@@ -2115,8 +2103,8 @@
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
+                "readable-stream": "2.3.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "blob": {
@@ -2131,7 +2119,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "bluebird": {
@@ -2152,15 +2140,15 @@
             "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
+                "depd": "1.1.2",
+                "http-errors": "1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
+                "type-is": "1.6.16"
             }
         },
         "boxen": {
@@ -2169,13 +2157,13 @@
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "dev": true,
             "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.4.1",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2202,8 +2190,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -2212,7 +2200,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -2222,7 +2210,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2231,16 +2219,16 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2248,7 +2236,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -2270,27 +2258,27 @@
             "integrity": "sha512-VLzpjCA4uXqfzkwqWtMM6hvPm2PNHp2RcmzBXcbi6C9WpkUhhFb8SVAr4CFrCsFxDg+oY6HalOjn8F+egyvhag==",
             "dev": true,
             "requires": {
-                "browser-sync-client": "^2.26.2",
-                "browser-sync-ui": "^2.26.2",
+                "browser-sync-client": "2.26.2",
+                "browser-sync-ui": "2.26.2",
                 "bs-recipes": "1.3.4",
-                "bs-snippet-injector": "^2.0.1",
-                "chokidar": "^2.0.4",
+                "bs-snippet-injector": "2.0.1",
+                "chokidar": "2.0.4",
                 "connect": "3.6.6",
-                "connect-history-api-fallback": "^1",
-                "dev-ip": "^1.0.1",
-                "easy-extender": "^2.3.4",
-                "eazy-logger": "^3",
-                "etag": "^1.8.1",
-                "fresh": "^0.5.2",
+                "connect-history-api-fallback": "1.5.0",
+                "dev-ip": "1.0.1",
+                "easy-extender": "2.3.4",
+                "eazy-logger": "3.0.2",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
-                "immutable": "^3",
+                "immutable": "3.8.2",
                 "localtunnel": "1.9.1",
                 "micromatch": "2.3.11",
                 "opn": "5.3.0",
                 "portscanner": "2.1.1",
                 "qs": "6.2.3",
-                "raw-body": "^2.3.2",
+                "raw-body": "2.3.3",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
                 "send": "0.16.2",
@@ -2308,7 +2296,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "array-unique": {
@@ -2323,9 +2311,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.3"
                     }
                 },
                 "camelcase": {
@@ -2346,7 +2334,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "^0.1.0"
+                        "is-posix-bracket": "0.1.1"
                     }
                 },
                 "extglob": {
@@ -2355,7 +2343,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "fs-extra": {
@@ -2364,9 +2352,9 @@
                     "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^3.0.0",
-                        "universalify": "^0.1.0"
+                        "graceful-fs": "4.1.15",
+                        "jsonfile": "3.0.1",
+                        "universalify": "0.1.2"
                     }
                 },
                 "is-extglob": {
@@ -2381,7 +2369,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "jsonfile": {
@@ -2390,7 +2378,7 @@
                     "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "graceful-fs": "4.1.15"
                     }
                 },
                 "kind-of": {
@@ -2399,7 +2387,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "micromatch": {
@@ -2408,19 +2396,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 },
                 "qs": {
@@ -2441,20 +2429,20 @@
                     "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "window-size": "^0.2.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.1.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "4.2.1"
                     }
                 },
                 "yargs-parser": {
@@ -2463,7 +2451,7 @@
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -2476,8 +2464,8 @@
             "requires": {
                 "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "mitt": "^1.1.3",
-                "rxjs": "^5.5.6"
+                "mitt": "1.1.3",
+                "rxjs": "5.5.12"
             }
         },
         "browser-sync-ui": {
@@ -2487,11 +2475,11 @@
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "^1",
-                "immutable": "^3",
+                "connect-history-api-fallback": "1.5.0",
+                "immutable": "3.8.2",
                 "server-destroy": "1.0.1",
-                "socket.io-client": "^2.0.4",
-                "stream-throttle": "^0.1.3"
+                "socket.io-client": "2.1.1",
+                "stream-throttle": "0.1.3"
             }
         },
         "browserify-aes": {
@@ -2500,12 +2488,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -2514,9 +2502,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.2",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -2525,10 +2513,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-rsa": {
@@ -2537,8 +2525,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
             }
         },
         "browserify-sign": {
@@ -2547,13 +2535,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.4.1",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.1"
             }
         },
         "browserify-zlib": {
@@ -2562,7 +2550,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "~1.0.5"
+                "pako": "1.0.6"
             }
         },
         "browserslist": {
@@ -2571,9 +2559,9 @@
             "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000899",
-                "electron-to-chromium": "^1.3.82",
-                "node-releases": "^1.0.1"
+                "caniuse-lite": "1.0.30000907",
+                "electron-to-chromium": "1.3.84",
+                "node-releases": "1.0.3"
             }
         },
         "bs-recipes": {
@@ -2595,8 +2583,8 @@
             "dev": true,
             "requires": {
                 "base64-js": "0.0.8",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "ieee754": "1.1.12",
+                "isarray": "1.0.0"
             }
         },
         "buffer-alloc": {
@@ -2605,8 +2593,8 @@
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
+                "buffer-alloc-unsafe": "1.1.0",
+                "buffer-fill": "1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -2660,19 +2648,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.3",
+                "chownr": "1.1.1",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.15",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.1",
+                "y18n": "4.0.0"
             },
             "dependencies": {
                 "y18n": {
@@ -2688,15 +2676,15 @@
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "call-me-maybe": {
@@ -2710,7 +2698,7 @@
             "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
             "dev": true,
             "requires": {
-                "callsites": "^2.0.0"
+                "callsites": "2.0.0"
             }
         },
         "caller-path": {
@@ -2719,7 +2707,7 @@
             "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
             "dev": true,
             "requires": {
-                "caller-callsite": "^2.0.0"
+                "caller-callsite": "2.0.0"
             }
         },
         "callsite": {
@@ -2746,8 +2734,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
             },
             "dependencies": {
                 "camelcase": {
@@ -2781,8 +2769,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
             }
         },
         "chalk": {
@@ -2790,9 +2778,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             }
         },
         "character-entities": {
@@ -2810,30 +2798,24 @@
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
             "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
         },
-        "chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
         "chokidar": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
             "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.2.2",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "lodash.debounce": "^4.0.8",
-                "normalize-path": "^2.1.1",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.5"
+                "anymatch": "2.0.0",
+                "async-each": "1.0.1",
+                "braces": "2.3.2",
+                "fsevents": "1.2.4",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.0",
+                "lodash.debounce": "4.0.8",
+                "normalize-path": "2.1.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.2.1",
+                "upath": "1.1.0"
             }
         },
         "chownr": {
@@ -2848,7 +2830,7 @@
             "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "1.9.3"
             }
         },
         "ci-info": {
@@ -2863,25 +2845,19 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
-        },
-        "circular-json": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -2889,7 +2865,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -2906,7 +2882,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-spinners": {
@@ -2922,14 +2898,8 @@
             "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
-                "string-width": "^1.0.1"
+                "string-width": "1.0.2"
             }
-        },
-        "cli-width": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-            "dev": true
         },
         "clipboard": {
             "version": "2.0.3",
@@ -2937,9 +2907,9 @@
             "integrity": "sha512-ZCKqjAwpnlZbzL7kFeihGKoMbs6sD5DnJfmtQZNnzaUbHGKjhTf+RYRUzbz+4xEl8pShaCstCc3cLNOEvCWskw==",
             "optional": true,
             "requires": {
-                "good-listener": "^1.2.2",
-                "select": "^1.1.2",
-                "tiny-emitter": "^2.0.0"
+                "good-listener": "1.2.2",
+                "select": "1.1.2",
+                "tiny-emitter": "2.0.2"
             }
         },
         "cliui": {
@@ -2947,9 +2917,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
             }
         },
         "clone": {
@@ -2976,9 +2946,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "code-point-at": {
@@ -2991,8 +2961,8 @@
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -3025,7 +2995,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "comma-separated-tokens": {
@@ -3069,10 +3039,10 @@
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "^0.2.1",
-                "crc32-stream": "^2.0.0",
-                "normalize-path": "^2.0.0",
-                "readable-stream": "^2.0.0"
+                "buffer-crc32": "0.2.13",
+                "crc32-stream": "2.0.0",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.6"
             }
         },
         "concat-map": {
@@ -3086,10 +3056,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "concat-with-sourcemaps": {
@@ -3098,7 +3068,7 @@
             "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
             "dev": true,
             "requires": {
-                "source-map": "^0.6.1"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -3114,8 +3084,8 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
             "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
             "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
             }
         },
         "configstore": {
@@ -3124,12 +3094,12 @@
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "dev": true,
             "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.15",
+                "make-dir": "1.3.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
             }
         },
         "connect": {
@@ -3140,7 +3110,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
-                "parseurl": "~1.3.2",
+                "parseurl": "1.3.2",
                 "utils-merge": "1.0.1"
             },
             "dependencies": {
@@ -3151,12 +3121,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "~1.0.1",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.3.1",
-                        "unpipe": "~1.0.0"
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
                     }
                 },
                 "statuses": {
@@ -3179,7 +3149,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "console-control-strings": {
@@ -3209,7 +3179,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "cookie": {
@@ -3233,7 +3203,7 @@
             "requires": {
                 "cookies": "0.7.1",
                 "debug": "3.1.0",
-                "on-headers": "~1.0.1",
+                "on-headers": "1.0.1",
                 "safe-buffer": "5.1.1"
             },
             "dependencies": {
@@ -3262,8 +3232,8 @@
             "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
             "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
             "requires": {
-                "depd": "~1.1.1",
-                "keygrip": "~1.0.2"
+                "depd": "1.1.2",
+                "keygrip": "1.0.3"
             }
         },
         "copy-concurrently": {
@@ -3272,12 +3242,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "copy-descriptor": {
@@ -3290,7 +3260,7 @@
             "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz",
             "integrity": "sha512-c3GdeY8qxCHGezVb1EFQfHYK/8NZRemgcTIzPq7PuxjHAf/raKibn2QdhHPb/y6q74PMgH6yizaDZlRmw6QyKw==",
             "requires": {
-                "toggle-selection": "^1.0.3"
+                "toggle-selection": "1.0.6"
             }
         },
         "core-js": {
@@ -3308,8 +3278,8 @@
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
             "requires": {
-                "object-assign": "^4",
-                "vary": "^1"
+                "object-assign": "4.1.1",
+                "vary": "1.1.2"
             }
         },
         "cosmiconfig": {
@@ -3318,10 +3288,10 @@
             "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
             "dev": true,
             "requires": {
-                "import-fresh": "^2.0.0",
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.9.0",
-                "parse-json": "^4.0.0"
+                "import-fresh": "2.0.0",
+                "is-directory": "0.3.1",
+                "js-yaml": "3.12.0",
+                "parse-json": "4.0.0"
             },
             "dependencies": {
                 "parse-json": {
@@ -3330,8 +3300,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 }
             }
@@ -3342,7 +3312,7 @@
             "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
             "dev": true,
             "requires": {
-                "buffer": "^5.1.0"
+                "buffer": "5.2.1"
             },
             "dependencies": {
                 "base64-js": {
@@ -3357,8 +3327,8 @@
                     "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
                     "dev": true,
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
+                        "base64-js": "1.3.0",
+                        "ieee754": "1.1.12"
                     }
                 }
             }
@@ -3369,8 +3339,8 @@
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "dev": true,
             "requires": {
-                "crc": "^3.4.4",
-                "readable-stream": "^2.0.0"
+                "crc": "3.8.0",
+                "readable-stream": "2.3.6"
             }
         },
         "create-ecdh": {
@@ -3379,8 +3349,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.1"
             }
         },
         "create-error-class": {
@@ -3389,7 +3359,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "^1.0.0"
+                "capture-stack-trace": "1.0.1"
             }
         },
         "create-hash": {
@@ -3398,11 +3368,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.5",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-hmac": {
@@ -3411,12 +3381,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "cross-env": {
@@ -3424,8 +3394,8 @@
             "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
             "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
             "requires": {
-                "cross-spawn": "^6.0.5",
-                "is-windows": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "is-windows": "1.0.2"
             }
         },
         "cross-spawn": {
@@ -3433,11 +3403,11 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.6.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "crypto-browserify": {
@@ -3446,17 +3416,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.17",
+                "public-encrypt": "4.0.3",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "crypto-random-string": {
@@ -3471,10 +3441,10 @@
             "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
+                "inherits": "2.0.3",
+                "source-map": "0.6.1",
+                "source-map-resolve": "0.5.2",
+                "urix": "0.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -3491,8 +3461,8 @@
             "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
             "dev": true,
             "requires": {
-                "mdn-data": "~1.1.0",
-                "source-map": "^0.5.3"
+                "mdn-data": "1.1.4",
+                "source-map": "0.5.7"
             }
         },
         "cssfilter": {
@@ -3519,7 +3489,7 @@
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
             "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.4"
             }
         },
         "currently-unhandled": {
@@ -3528,7 +3498,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "^1.0.1"
+                "array-find-index": "1.0.2"
             }
         },
         "cycle": {
@@ -3549,7 +3519,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "0.10.46"
             }
         },
         "dargs": {
@@ -3563,7 +3533,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "date-fns": {
@@ -3598,9 +3568,9 @@
             "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
             "dev": true,
             "requires": {
-                "debug": "3.X",
-                "memoizee": "0.4.X",
-                "object-assign": "4.X"
+                "debug": "3.2.6",
+                "memoizee": "0.4.14",
+                "object-assign": "4.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -3609,7 +3579,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -3640,14 +3610,14 @@
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.0.0",
-                "decompress-tarbz2": "^4.0.0",
-                "decompress-targz": "^4.0.0",
-                "decompress-unzip": "^4.0.1",
-                "graceful-fs": "^4.1.10",
-                "make-dir": "^1.0.0",
-                "pify": "^2.3.0",
-                "strip-dirs": "^2.0.0"
+                "decompress-tar": "4.1.1",
+                "decompress-tarbz2": "4.1.1",
+                "decompress-targz": "4.1.1",
+                "decompress-unzip": "4.0.1",
+                "graceful-fs": "4.1.15",
+                "make-dir": "1.3.0",
+                "pify": "2.3.0",
+                "strip-dirs": "2.1.0"
             },
             "dependencies": {
                 "pify": {
@@ -3664,9 +3634,9 @@
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
             "requires": {
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0",
-                "tar-stream": "^1.5.2"
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0",
+                "tar-stream": "1.6.2"
             }
         },
         "decompress-tarbz2": {
@@ -3675,11 +3645,11 @@
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.1.0",
-                "file-type": "^6.1.0",
-                "is-stream": "^1.1.0",
-                "seek-bzip": "^1.0.5",
-                "unbzip2-stream": "^1.0.9"
+                "decompress-tar": "4.1.1",
+                "file-type": "6.2.0",
+                "is-stream": "1.1.0",
+                "seek-bzip": "1.0.5",
+                "unbzip2-stream": "1.3.1"
             },
             "dependencies": {
                 "file-type": {
@@ -3696,9 +3666,9 @@
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.1.1",
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0"
+                "decompress-tar": "4.1.1",
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0"
             }
         },
         "decompress-unzip": {
@@ -3707,10 +3677,10 @@
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
             "requires": {
-                "file-type": "^3.8.0",
-                "get-stream": "^2.2.0",
-                "pify": "^2.3.0",
-                "yauzl": "^2.4.2"
+                "file-type": "3.9.0",
+                "get-stream": "2.3.1",
+                "pify": "2.3.0",
+                "yauzl": "2.10.0"
             },
             "dependencies": {
                 "file-type": {
@@ -3744,19 +3714,13 @@
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
         },
-        "deep-is": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
-        },
         "defaults": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "clone": "1.0.4"
             }
         },
         "define-properties": {
@@ -3764,7 +3728,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.0.12"
             }
         },
         "define-property": {
@@ -3772,8 +3736,8 @@
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -3781,7 +3745,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3789,7 +3753,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3797,9 +3761,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -3810,12 +3774,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "^6.1.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "p-map": "^1.1.1",
-                "pify": "^3.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "6.1.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "p-map": "1.2.0",
+                "pify": "3.0.0",
+                "rimraf": "2.6.2"
             },
             "dependencies": {
                 "globby": {
@@ -3824,11 +3788,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "^1.0.1",
-                        "glob": "^7.0.3",
-                        "object-assign": "^4.0.1",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "array-union": "1.0.2",
+                        "glob": "7.1.3",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     },
                     "dependencies": {
                         "pify": {
@@ -3875,8 +3839,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "destroy": {
@@ -3908,9 +3872,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
             }
         },
         "dir-glob": {
@@ -3918,8 +3882,8 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "requires": {
-                "arrify": "^1.0.1",
-                "path-type": "^3.0.0"
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
             }
         },
         "directory-tree": {
@@ -3933,7 +3897,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.2"
             }
         },
         "dom-serializer": {
@@ -3941,8 +3905,8 @@
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "1.1.3",
+                "entities": "1.1.2"
             },
             "dependencies": {
                 "domelementtype": {
@@ -3968,7 +3932,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "requires": {
-                "domelementtype": "1"
+                "domelementtype": "1.3.0"
             }
         },
         "domutils": {
@@ -3976,8 +3940,8 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
             }
         },
         "dot-prop": {
@@ -3986,7 +3950,7 @@
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "duplexer2": {
@@ -3995,7 +3959,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "~1.1.9"
+                "readable-stream": "1.1.14"
             },
             "dependencies": {
                 "isarray": {
@@ -4010,10 +3974,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -4036,10 +4000,10 @@
             "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "easy-extender": {
@@ -4048,7 +4012,7 @@
             "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.11"
             }
         },
         "eazy-logger": {
@@ -4057,7 +4021,7 @@
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "dev": true,
             "requires": {
-                "tfunk": "^3.0.1"
+                "tfunk": "3.1.0"
             }
         },
         "ecc-jsbn": {
@@ -4065,8 +4029,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "editorconfig": {
@@ -4074,12 +4038,12 @@
             "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.2.tgz",
             "integrity": "sha512-GWjSI19PVJAM9IZRGOS+YKI8LN+/sjkSjNyvxL5ucqP9/IqtYNXBaQ/6c/hkPNYQHyOHra2KoXZI/JVpuqwmcQ==",
             "requires": {
-                "@types/node": "^10.11.7",
-                "@types/semver": "^5.5.0",
-                "commander": "^2.19.0",
-                "lru-cache": "^4.1.3",
-                "semver": "^5.6.0",
-                "sigmund": "^1.0.1"
+                "@types/node": "10.12.5",
+                "@types/semver": "5.5.0",
+                "commander": "2.19.0",
+                "lru-cache": "4.1.3",
+                "semver": "5.6.0",
+                "sigmund": "1.0.1"
             }
         },
         "ee-first": {
@@ -4105,13 +4069,13 @@
             "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.5",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "emojis-list": {
@@ -4130,7 +4094,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "~0.4.13"
+                "iconv-lite": "0.4.23"
             }
         },
         "end-of-stream": {
@@ -4139,7 +4103,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "engine.io": {
@@ -4148,12 +4112,12 @@
             "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.4",
+                "accepts": "1.3.5",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.0",
-                "ws": "~3.3.1"
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.3",
+                "ws": "3.3.3"
             },
             "dependencies": {
                 "debug": {
@@ -4175,14 +4139,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.1",
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.3",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
-                "xmlhttprequest-ssl": "~1.5.4",
+                "ws": "3.3.3",
+                "xmlhttprequest-ssl": "1.5.5",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -4204,10 +4168,10 @@
             "dev": true,
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "~0.0.7",
+                "arraybuffer.slice": "0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.5",
-                "has-binary2": "~1.0.2"
+                "has-binary2": "1.0.3"
             }
         },
         "enhanced-resolve": {
@@ -4216,9 +4180,9 @@
             "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "4.1.15",
+                "memory-fs": "0.4.1",
+                "tapable": "1.1.0"
             }
         },
         "entities": {
@@ -4232,7 +4196,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -4240,7 +4204,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "error-stack-parser": {
@@ -4248,7 +4212,7 @@
             "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
             "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
             "requires": {
-                "stackframe": "^0.3.1"
+                "stackframe": "0.3.1"
             }
         },
         "es-abstract": {
@@ -4256,11 +4220,11 @@
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "requires": {
-                "es-to-primitive": "^1.1.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4"
             }
         },
         "es-to-primitive": {
@@ -4268,9 +4232,9 @@
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "es5-ext": {
@@ -4279,9 +4243,9 @@
             "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
             "dev": true,
             "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "1"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
             }
         },
         "es6-iterator": {
@@ -4290,9 +4254,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.46",
+                "es6-symbol": "3.1.1"
             }
         },
         "es6-promise": {
@@ -4306,8 +4270,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.46"
             }
         },
         "es6-weak-map": {
@@ -4316,10 +4280,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.46",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
             }
         },
         "escape-html": {
@@ -4332,101 +4296,17 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
-        "eslint": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
-            "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.5.3",
-                "chalk": "^2.1.0",
-                "cross-spawn": "^6.0.5",
-                "debug": "^4.0.1",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^4.0.0",
-                "eslint-utils": "^1.3.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^4.0.0",
-                "esquery": "^1.0.1",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.7.0",
-                "ignore": "^4.0.6",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^6.1.0",
-                "is-resolvable": "^1.1.0",
-                "js-yaml": "^3.12.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.5",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
-                "progress": "^2.0.0",
-                "regexpp": "^2.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.5.1",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "^2.0.1",
-                "table": "^5.0.2",
-                "text-table": "^0.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "eslint-plugin-react": {
             "version": "7.11.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
             "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "doctrine": "^2.1.0",
-                "has": "^1.0.3",
-                "jsx-ast-utils": "^2.0.1",
-                "prop-types": "^15.6.2"
+                "array-includes": "3.0.3",
+                "doctrine": "2.1.0",
+                "has": "1.0.3",
+                "jsx-ast-utils": "2.0.1",
+                "prop-types": "15.6.2"
             }
         },
         "eslint-scope": {
@@ -4435,15 +4315,9 @@
             "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
-        },
-        "eslint-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-            "dev": true
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -4451,39 +4325,11 @@
             "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
             "dev": true
         },
-        "espree": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-            "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
-            "dev": true,
-            "requires": {
-                "acorn": "^6.0.2",
-                "acorn-jsx": "^5.0.0",
-                "eslint-visitor-keys": "^1.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "6.0.4",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-                    "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
-                    "dev": true
-                }
-            }
-        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
-        },
-        "esquery": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^4.0.0"
-            }
         },
         "esrecurse": {
             "version": "4.2.1",
@@ -4491,7 +4337,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -4517,8 +4363,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.46"
             }
         },
         "eventemitter3": {
@@ -4539,8 +4385,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.5",
+                "safe-buffer": "5.1.2"
             }
         },
         "execa": {
@@ -4549,13 +4395,13 @@
             "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -4564,9 +4410,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "get-stream": {
@@ -4593,13 +4439,13 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4607,7 +4453,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -4615,7 +4461,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -4626,7 +4472,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
@@ -4635,11 +4481,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "3.1.1",
+                        "repeat-element": "1.1.3",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "is-number": {
@@ -4648,7 +4494,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "isobject": {
@@ -4666,7 +4512,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4677,7 +4523,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "express": {
@@ -4685,36 +4531,36 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.4",
+                "proxy-addr": "2.0.4",
                 "qs": "6.5.2",
-                "range-parser": "~1.2.0",
+                "range-parser": "1.2.0",
                 "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "vary": "1.1.2"
             },
             "dependencies": {
                 "statuses": {
@@ -4729,9 +4575,9 @@
             "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.5.0.tgz",
             "integrity": "sha512-rYXjOj+ldSDZdmCxRDX/7o6Oxtz45sS9l4QTsvqm+ZFxqI5xTA4usMMP4FBrrKTpDPuQkI2YVda+0LvkJhPu7A==",
             "requires": {
-                "debug": "^3.0.1",
-                "es6-promise": "^4.1.1",
-                "raw-body": "^2.3.0"
+                "debug": "3.2.6",
+                "es6-promise": "4.2.5",
+                "raw-body": "2.3.3"
             },
             "dependencies": {
                 "debug": {
@@ -4739,7 +4585,7 @@
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -4759,8 +4605,8 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4768,29 +4614,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
-                    }
-                }
-            }
-        },
-        "external-editor": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-            "dev": true,
-            "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "dev": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -4800,14 +4624,14 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4815,7 +4639,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -4823,7 +4647,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4831,7 +4655,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -4839,7 +4663,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -4847,9 +4671,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -4871,9 +4695,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
             }
         },
         "fast-deep-equal": {
@@ -4886,12 +4710,12 @@
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
             "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
             "requires": {
-                "@mrmlnc/readdir-enhanced": "^2.2.1",
-                "@nodelib/fs.stat": "^1.1.2",
-                "glob-parent": "^3.1.0",
-                "is-glob": "^4.0.0",
-                "merge2": "^1.2.3",
-                "micromatch": "^3.1.10"
+                "@mrmlnc/readdir-enhanced": "2.2.1",
+                "@nodelib/fs.stat": "1.1.3",
+                "glob-parent": "3.1.0",
+                "is-glob": "4.0.0",
+                "merge2": "1.2.3",
+                "micromatch": "3.1.10"
             }
         },
         "fast-json-stable-stringify": {
@@ -4899,18 +4723,12 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
-        },
         "fault": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
             "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
             "requires": {
-                "format": "^0.2.2"
+                "format": "0.2.2"
             }
         },
         "fbjs": {
@@ -4918,13 +4736,13 @@
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
             "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
             "requires": {
-                "core-js": "^1.0.0",
-                "isomorphic-fetch": "^2.1.1",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^0.7.18"
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.19"
             },
             "dependencies": {
                 "core-js": {
@@ -4940,7 +4758,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -4949,18 +4767,8 @@
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-            }
-        },
-        "file-entry-cache": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-            "dev": true,
-            "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
             }
         },
         "file-type": {
@@ -4980,10 +4788,10 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4991,7 +4799,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5002,12 +4810,12 @@
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
-                "unpipe": "~1.0.0"
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.4.0",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
                 "statuses": {
@@ -5023,8 +4831,8 @@
             "integrity": "sha1-rMAQQ6Z0n+w0Qpvmtk9ULrtdY1U=",
             "dev": true,
             "requires": {
-                "json5": "^0.5.1",
-                "path-exists": "^3.0.0"
+                "json5": "0.5.1",
+                "path-exists": "3.0.0"
             }
         },
         "find-cache-dir": {
@@ -5032,9 +4840,9 @@
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "1.3.0",
+                "pkg-dir": "2.0.0"
             }
         },
         "find-index": {
@@ -5054,7 +4862,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "findup-sync": {
@@ -5063,10 +4871,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
             },
             "dependencies": {
                 "is-glob": {
@@ -5075,7 +4883,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -5086,11 +4894,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "is-plain-object": "^2.0.3",
-                "object.defaults": "^1.1.0",
-                "object.pick": "^1.2.0",
-                "parse-filepath": "^1.0.1"
+                "expand-tilde": "2.0.2",
+                "is-plain-object": "2.0.4",
+                "object.defaults": "1.1.0",
+                "object.pick": "1.3.0",
+                "parse-filepath": "1.0.2"
             }
         },
         "first-chunk-stream": {
@@ -5105,26 +4913,14 @@
             "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
             "dev": true
         },
-        "flat-cache": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-            "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
-            "dev": true,
-            "requires": {
-                "circular-json": "^0.3.1",
-                "graceful-fs": "^4.1.2",
-                "rimraf": "~2.6.2",
-                "write": "^0.2.1"
-            }
-        },
         "flush-write-stream": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "folder-zipper": {
@@ -5133,8 +4929,8 @@
             "integrity": "sha512-Zwf4UfKy6fnV452UNglw3yQE1ny6/ULDcnG0E96Q71ZicCFDv7cFZumZxF7SEvOZPG5BnB/3WDQ9E0WjETtLmA==",
             "dev": true,
             "requires": {
-                "archiver": "^3.0.0",
-                "fs-extra": "^7.0.0"
+                "archiver": "3.0.0",
+                "fs-extra": "7.0.1"
             }
         },
         "follow-redirects": {
@@ -5142,7 +4938,7 @@
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
             "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
             "requires": {
-                "debug": "=3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -5166,7 +4962,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -5185,9 +4981,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.21"
             }
         },
         "format": {
@@ -5205,7 +5001,7 @@
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -5219,8 +5015,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "fs-constants": {
@@ -5235,9 +5031,9 @@
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.15",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.2"
             }
         },
         "fs-readdir-recursive": {
@@ -5251,10 +5047,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.15",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.6"
             }
         },
         "fs.realpath": {
@@ -5268,8 +5064,8 @@
             "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "2.11.1",
+                "node-pre-gyp": "0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -5291,8 +5087,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -5303,7 +5099,7 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -5357,7 +5153,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
@@ -5370,14 +5166,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     }
                 },
                 "glob": {
@@ -5385,12 +5181,12 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -5403,7 +5199,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -5411,7 +5207,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -5419,8 +5215,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -5436,7 +5232,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -5448,7 +5244,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -5459,8 +5255,8 @@
                     "version": "2.2.4",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "minizlib": {
@@ -5468,7 +5264,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "mkdirp": {
@@ -5488,9 +5284,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -5498,16 +5294,16 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.7",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -5515,8 +5311,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -5529,8 +5325,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
@@ -5538,10 +5334,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -5557,7 +5353,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -5575,8 +5371,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -5594,10 +5390,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -5612,13 +5408,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -5626,7 +5422,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
@@ -5662,9 +5458,9 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -5672,14 +5468,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -5692,13 +5488,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -5711,7 +5507,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -5730,10 +5526,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.15",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "function-bind": {
@@ -5741,26 +5537,20 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
-        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.3"
             }
         },
         "gaze": {
@@ -5769,7 +5559,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "~0.1.0"
+                "globule": "0.1.0"
             }
         },
         "get-caller-file": {
@@ -5796,8 +5586,8 @@
             "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
             "dev": true,
             "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
             }
         },
         "get-value": {
@@ -5810,7 +5600,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -5818,12 +5608,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -5832,8 +5622,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -5842,7 +5632,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -5857,7 +5647,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -5867,8 +5657,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             },
             "dependencies": {
                 "is-glob": {
@@ -5876,7 +5666,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -5887,12 +5677,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
+                "glob": "4.5.3",
+                "glob2base": "0.0.12",
+                "minimatch": "2.0.10",
+                "ordered-read-streams": "0.1.0",
+                "through2": "0.6.5",
+                "unique-stream": "1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -5901,10 +5691,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^2.0.1",
-                        "once": "^1.3.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "2.0.10",
+                        "once": "1.4.0"
                     }
                 },
                 "isarray": {
@@ -5919,7 +5709,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.0.0"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "readable-stream": {
@@ -5928,10 +5718,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -5946,8 +5736,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -5963,7 +5753,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
+                "gaze": "0.5.2"
             }
         },
         "glob2base": {
@@ -5972,7 +5762,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "^0.1.1"
+                "find-index": "0.1.1"
             }
         },
         "global-dirs": {
@@ -5981,7 +5771,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "^1.3.4"
+                "ini": "1.3.5"
             }
         },
         "global-modules": {
@@ -5990,9 +5780,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
+                "global-prefix": "1.0.2",
+                "is-windows": "1.0.2",
+                "resolve-dir": "1.0.1"
             }
         },
         "global-prefix": {
@@ -6001,11 +5791,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
+                "expand-tilde": "2.0.2",
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "1.0.2",
+                "which": "1.3.1"
             }
         },
         "globals": {
@@ -6019,13 +5809,13 @@
             "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
             "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
             "requires": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "fast-glob": "^2.0.2",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "fast-glob": "2.2.4",
+                "glob": "7.1.3",
+                "ignore": "3.3.10",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
             },
             "dependencies": {
                 "slash": {
@@ -6041,9 +5831,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
+                "glob": "3.1.21",
+                "lodash": "1.0.2",
+                "minimatch": "0.2.14"
             },
             "dependencies": {
                 "glob": {
@@ -6052,9 +5842,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
+                        "graceful-fs": "1.2.3",
+                        "inherits": "1.0.2",
+                        "minimatch": "0.2.14"
                     }
                 },
                 "graceful-fs": {
@@ -6087,8 +5877,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
                     }
                 }
             }
@@ -6099,7 +5889,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "good-listener": {
@@ -6108,7 +5898,7 @@
             "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
             "optional": true,
             "requires": {
-                "delegate": "^3.1.2"
+                "delegate": "3.2.0"
             }
         },
         "got": {
@@ -6117,17 +5907,17 @@
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "^3.0.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "unzip-response": "^2.0.1",
-                "url-parse-lax": "^1.0.0"
+                "create-error-class": "3.0.2",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-redirect": "1.0.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "lowercase-keys": "1.0.1",
+                "safe-buffer": "5.1.2",
+                "timed-out": "4.0.1",
+                "unzip-response": "2.0.1",
+                "url-parse-lax": "1.0.0"
             },
             "dependencies": {
                 "get-stream": {
@@ -6160,19 +5950,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "archy": "1.0.0",
+                "chalk": "1.1.3",
+                "deprecated": "0.0.1",
+                "gulp-util": "3.0.8",
+                "interpret": "1.1.0",
+                "liftoff": "2.5.0",
+                "minimist": "1.2.0",
+                "orchestrator": "0.3.8",
+                "pretty-hrtime": "1.0.3",
+                "semver": "4.3.6",
+                "tildify": "1.2.0",
+                "v8flags": "2.1.1",
+                "vinyl-fs": "0.3.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6187,11 +5977,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "minimist": {
@@ -6218,7 +6008,7 @@
                     "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
                     "dev": true,
                     "requires": {
-                        "user-home": "^1.1.1"
+                        "user-home": "1.1.1"
                     }
                 }
             }
@@ -6229,12 +6019,12 @@
             "integrity": "sha1-gjfCeKaXdScKHK/n1vEBz81YVUQ=",
             "dev": true,
             "requires": {
-                "autoprefixer": "^8.0.0",
-                "fancy-log": "^1.3.2",
-                "plugin-error": "^1.0.1",
-                "postcss": "^6.0.1",
-                "through2": "^2.0.0",
-                "vinyl-sourcemaps-apply": "^0.2.0"
+                "autoprefixer": "8.6.5",
+                "fancy-log": "1.3.2",
+                "plugin-error": "1.0.1",
+                "postcss": "6.0.23",
+                "through2": "2.0.5",
+                "vinyl-sourcemaps-apply": "0.2.1"
             }
         },
         "gulp-concat": {
@@ -6243,9 +6033,9 @@
             "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
             "dev": true,
             "requires": {
-                "concat-with-sourcemaps": "^1.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^2.0.0"
+                "concat-with-sourcemaps": "1.1.0",
+                "through2": "2.0.5",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -6272,12 +6062,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -6288,9 +6078,9 @@
             "integrity": "sha512-zhkvq06x1SJrpBN8YNJfc1PDono2+xjB6nI9UmBPh88nS4Weuz0hZMgJ4YruOw9Bf+oDrX71U6pkos6pIQhc1g==",
             "dev": true,
             "requires": {
-                "csso": "^3.0.0",
-                "plugin-error": "^0.1.2",
-                "vinyl-sourcemaps-apply": "^0.2.1"
+                "csso": "3.5.1",
+                "plugin-error": "0.1.2",
+                "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -6299,8 +6089,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
                     }
                 },
                 "arr-union": {
@@ -6321,7 +6111,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^1.1.0"
+                        "kind-of": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -6336,11 +6126,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "^0.1.1",
-                        "ansi-red": "^0.1.1",
-                        "arr-diff": "^1.0.1",
-                        "arr-union": "^2.0.1",
-                        "extend-shallow": "^1.1.2"
+                        "ansi-cyan": "0.1.1",
+                        "ansi-red": "0.1.1",
+                        "arr-diff": "1.1.0",
+                        "arr-union": "2.1.0",
+                        "extend-shallow": "1.1.4"
                     }
                 }
             }
@@ -6351,9 +6141,9 @@
             "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
             "dev": true,
             "requires": {
-                "gulp-match": "^1.0.3",
-                "ternary-stream": "^2.0.1",
-                "through2": "^2.0.1"
+                "gulp-match": "1.0.3",
+                "ternary-stream": "2.0.1",
+                "through2": "2.0.5"
             }
         },
         "gulp-install": {
@@ -6362,12 +6152,12 @@
             "integrity": "sha1-k4a0bLRmm0cle2rfTj6i6DySiho=",
             "dev": true,
             "requires": {
-                "dargs": "^5.1.0",
-                "gulp-util": "^3.0.7",
-                "lodash.groupby": "^4.6.0",
-                "p-queue": "^1.0.0",
-                "through2": "^2.0.3",
-                "which": "^1.2.14"
+                "dargs": "5.1.0",
+                "gulp-util": "3.0.8",
+                "lodash.groupby": "4.6.0",
+                "p-queue": "1.2.0",
+                "through2": "2.0.5",
+                "which": "1.3.1"
             }
         },
         "gulp-less": {
@@ -6376,13 +6166,13 @@
             "integrity": "sha512-hmM2k0FfQp7Ptm3ZaqO2CkMX3hqpiIOn4OHtuSsCeFym63F7oWlEua5v6u1cIjVUKYsVIs9zPg9vbqTEb/udpA==",
             "dev": true,
             "requires": {
-                "accord": "^0.29.0",
-                "less": "2.6.x || ^3.7.1",
-                "object-assign": "^4.0.1",
-                "plugin-error": "^0.1.2",
-                "replace-ext": "^1.0.0",
-                "through2": "^2.0.0",
-                "vinyl-sourcemaps-apply": "^0.2.0"
+                "accord": "0.29.0",
+                "less": "3.8.1",
+                "object-assign": "4.1.1",
+                "plugin-error": "0.1.2",
+                "replace-ext": "1.0.0",
+                "through2": "2.0.5",
+                "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -6391,8 +6181,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
                     }
                 },
                 "arr-union": {
@@ -6413,7 +6203,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^1.1.0"
+                        "kind-of": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -6428,11 +6218,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "^0.1.1",
-                        "ansi-red": "^0.1.1",
-                        "arr-diff": "^1.0.1",
-                        "arr-union": "^2.0.1",
-                        "extend-shallow": "^1.1.2"
+                        "ansi-cyan": "0.1.1",
+                        "ansi-red": "0.1.1",
+                        "arr-diff": "1.1.0",
+                        "arr-union": "2.1.0",
+                        "extend-shallow": "1.1.4"
                     }
                 },
                 "replace-ext": {
@@ -6449,7 +6239,7 @@
             "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
             "dev": true,
             "requires": {
-                "minimatch": "^3.0.3"
+                "minimatch": "3.0.4"
             }
         },
         "gulp-rename": {
@@ -6464,10 +6254,10 @@
             "integrity": "sha1-4XwKy3wwtuKu7iPAREKpbAys7/o=",
             "dev": true,
             "requires": {
-                "gulp-util": "^3.0.0",
-                "lodash.defaults": "^4.0.1",
-                "lodash.template": "^4.0.2",
-                "vinyl": "^0.4.6"
+                "gulp-util": "3.0.8",
+                "lodash.defaults": "4.2.0",
+                "lodash.template": "4.4.0",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -6482,8 +6272,8 @@
                     "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0",
-                        "lodash.templatesettings": "^4.0.0"
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.templatesettings": "4.1.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -6492,7 +6282,7 @@
                     "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0"
+                        "lodash._reinterpolate": "3.0.0"
                     }
                 },
                 "vinyl": {
@@ -6501,8 +6291,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -6513,14 +6303,14 @@
             "integrity": "sha512-q8psj4+aDrblJMMtRxihNBdovfzGrXJp1l4JU0Sz4b/Mhsi2DPrKFYCGDwjIWRENs04ELVHxdOJQ7Vs98OFohg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "lodash.clonedeep": "^4.3.2",
-                "node-sass": "^4.8.3",
-                "plugin-error": "^1.0.1",
-                "replace-ext": "^1.0.0",
-                "strip-ansi": "^4.0.0",
-                "through2": "^2.0.0",
-                "vinyl-sourcemaps-apply": "^0.2.0"
+                "chalk": "2.4.1",
+                "lodash.clonedeep": "4.5.0",
+                "node-sass": "4.10.0",
+                "plugin-error": "1.0.1",
+                "replace-ext": "1.0.0",
+                "strip-ansi": "4.0.0",
+                "through2": "2.0.5",
+                "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6541,7 +6331,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -6552,17 +6342,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.X",
-                "@gulp-sourcemaps/map-sources": "1.X",
-                "acorn": "5.X",
-                "convert-source-map": "1.X",
-                "css": "2.X",
-                "debug-fabulous": "1.X",
-                "detect-newline": "2.X",
-                "graceful-fs": "4.X",
-                "source-map": "~0.6.0",
-                "strip-bom-string": "1.X",
-                "through2": "2.X"
+                "@gulp-sourcemaps/identity-map": "1.0.2",
+                "@gulp-sourcemaps/map-sources": "1.0.0",
+                "acorn": "5.7.3",
+                "convert-source-map": "1.6.0",
+                "css": "2.2.4",
+                "debug-fabulous": "1.1.0",
+                "detect-newline": "2.1.0",
+                "graceful-fs": "4.1.15",
+                "source-map": "0.6.1",
+                "strip-bom-string": "1.0.0",
+                "through2": "2.0.5"
             },
             "dependencies": {
                 "source-map": {
@@ -6579,24 +6369,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
+                "through2": "2.0.5",
+                "vinyl": "0.5.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6611,11 +6401,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "minimist": {
@@ -6645,17 +6435,17 @@
             "dev": true,
             "requires": {
                 "ansi-colors": "1.1.0",
-                "anymatch": "^1.3.0",
-                "chokidar": "^2.0.0",
+                "anymatch": "1.3.2",
+                "chokidar": "2.0.4",
                 "fancy-log": "1.3.2",
-                "glob-parent": "^3.0.1",
-                "object-assign": "^4.1.0",
-                "path-is-absolute": "^1.0.1",
+                "glob-parent": "3.1.0",
+                "object-assign": "4.1.1",
+                "path-is-absolute": "1.0.1",
                 "plugin-error": "1.0.1",
-                "readable-stream": "^2.2.2",
-                "slash": "^1.0.0",
-                "vinyl": "^2.1.0",
-                "vinyl-file": "^2.0.0"
+                "readable-stream": "2.3.6",
+                "slash": "1.0.0",
+                "vinyl": "2.2.0",
+                "vinyl-file": "2.0.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -6664,8 +6454,8 @@
                     "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^2.1.5",
-                        "normalize-path": "^2.0.0"
+                        "micromatch": "2.3.11",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -6674,7 +6464,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "array-unique": {
@@ -6689,9 +6479,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.3"
                     }
                 },
                 "clone": {
@@ -6712,7 +6502,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "^0.1.0"
+                        "is-posix-bracket": "0.1.1"
                     }
                 },
                 "extglob": {
@@ -6721,7 +6511,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -6736,7 +6526,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "kind-of": {
@@ -6745,7 +6535,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "micromatch": {
@@ -6754,19 +6544,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 },
                 "replace-ext": {
@@ -6787,12 +6577,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -6803,7 +6593,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "^1.0.0"
+                "glogg": "1.0.1"
             }
         },
         "handlebars": {
@@ -6812,10 +6602,10 @@
             "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "async": "2.6.1",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.4.9"
             },
             "dependencies": {
                 "source-map": {
@@ -6836,8 +6626,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.5.5",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -6845,7 +6635,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -6854,7 +6644,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-binary2": {
@@ -6891,7 +6681,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "has-symbols": {
@@ -6910,9 +6700,9 @@
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -6920,8 +6710,8 @@
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -6929,7 +6719,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -6940,8 +6730,8 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -6950,8 +6740,8 @@
             "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "hast-util-parse-selector": {
@@ -6964,10 +6754,10 @@
             "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-4.1.0.tgz",
             "integrity": "sha512-bOTn9hEfzewvHyXdbYGKqOr/LOz+2zYhKbC17U2YAjd16mnjqB1BQ0nooM/RdMy/htVyli0NAznXiBtwDi1cmQ==",
             "requires": {
-                "comma-separated-tokens": "^1.0.0",
-                "hast-util-parse-selector": "^2.2.0",
-                "property-information": "^4.0.0",
-                "space-separated-tokens": "^1.0.0"
+                "comma-separated-tokens": "1.0.5",
+                "hast-util-parse-selector": "2.2.1",
+                "property-information": "4.2.0",
+                "space-separated-tokens": "1.1.2"
             }
         },
         "highlight.js": {
@@ -6980,11 +6770,11 @@
             "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
             "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
             "requires": {
-                "invariant": "^2.2.1",
-                "loose-envify": "^1.2.0",
-                "resolve-pathname": "^2.2.0",
-                "value-equal": "^0.4.0",
-                "warning": "^3.0.0"
+                "invariant": "2.2.4",
+                "loose-envify": "1.4.0",
+                "resolve-pathname": "2.2.0",
+                "value-equal": "0.4.0",
+                "warning": "3.0.0"
             },
             "dependencies": {
                 "warning": {
@@ -6992,7 +6782,7 @@
                     "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
                     "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
                     "requires": {
-                        "loose-envify": "^1.0.0"
+                        "loose-envify": "1.4.0"
                     }
                 }
             }
@@ -7003,9 +6793,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.5",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoist-non-react-statics": {
@@ -7013,7 +6803,7 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
             "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
             "requires": {
-                "react-is": "^16.3.2"
+                "react-is": "16.6.1"
             }
         },
         "home-or-tmp": {
@@ -7026,7 +6816,7 @@
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "requires": {
-                "parse-passwd": "^1.0.0"
+                "parse-passwd": "1.0.0"
             }
         },
         "hosted-git-info": {
@@ -7045,12 +6835,12 @@
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
             "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
             "requires": {
-                "domelementtype": "^1.3.0",
-                "domhandler": "^2.3.0",
-                "domutils": "^1.5.1",
-                "entities": "^1.1.1",
-                "inherits": "^2.0.1",
-                "readable-stream": "^3.0.6"
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.2",
+                "domutils": "1.7.0",
+                "entities": "1.1.2",
+                "inherits": "2.0.3",
+                "readable-stream": "3.0.6"
             },
             "dependencies": {
                 "readable-stream": {
@@ -7058,9 +6848,9 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
                     "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
                     "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
+                        "inherits": "2.0.3",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 }
             }
@@ -7070,10 +6860,10 @@
             "resolved": "https://registry.npmjs.org/htmltojsx/-/htmltojsx-0.3.0.tgz",
             "integrity": "sha1-ZIfEUE1mAFHkn3OhJ7RV12PfgmY=",
             "requires": {
-                "jsdom-no-contextify": "~3.1.0",
-                "react": "~15.4.1",
-                "react-dom": "~15.4.1",
-                "yargs": "~4.6.0"
+                "jsdom-no-contextify": "3.1.0",
+                "react": "15.4.2",
+                "react-dom": "15.4.2",
+                "yargs": "4.6.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7091,9 +6881,9 @@
                     "resolved": "http://registry.npmjs.org/react/-/react-15.4.2.tgz",
                     "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
                     "requires": {
-                        "fbjs": "^0.8.4",
-                        "loose-envify": "^1.1.0",
-                        "object-assign": "^4.1.0"
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1"
                     }
                 },
                 "react-dom": {
@@ -7101,9 +6891,9 @@
                     "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
                     "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
                     "requires": {
-                        "fbjs": "^0.8.1",
-                        "loose-envify": "^1.1.0",
-                        "object-assign": "^4.1.0"
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1"
                     }
                 },
                 "yargs": {
@@ -7111,18 +6901,18 @@
                     "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.6.0.tgz",
                     "integrity": "sha1-y0BQwBWb+2u2ScD0r1UFJqhGGdw=",
                     "requires": {
-                        "camelcase": "^2.0.1",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "lodash.assign": "^4.0.3",
-                        "os-locale": "^1.4.0",
-                        "pkg-conf": "^1.1.2",
-                        "read-pkg-up": "^1.0.1",
-                        "require-main-filename": "^1.0.1",
-                        "string-width": "^1.0.1",
-                        "window-size": "^0.2.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^2.4.0"
+                        "camelcase": "2.1.1",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "lodash.assign": "4.2.0",
+                        "os-locale": "1.4.0",
+                        "pkg-conf": "1.1.3",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1",
+                        "string-width": "1.0.2",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "2.4.1"
                     }
                 }
             }
@@ -7132,10 +6922,10 @@
             "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-3.2.3.tgz",
             "integrity": "sha1-Y2hCtx1uHyyY26Ca9UQXof74thw=",
             "requires": {
-                "apache-crypt": "^1.1.2",
-                "apache-md5": "^1.0.6",
-                "bcryptjs": "^2.3.0",
-                "uuid": "^3.0.0"
+                "apache-crypt": "1.2.1",
+                "apache-md5": "1.1.2",
+                "bcryptjs": "2.4.3",
+                "uuid": "3.3.2"
             }
         },
         "http-errors": {
@@ -7143,10 +6933,10 @@
             "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
-                "depd": "~1.1.2",
+                "depd": "1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "statuses": "1.5.0"
             }
         },
         "http-proxy": {
@@ -7155,8 +6945,8 @@
             "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.x.x",
-                "requires-port": "1.x.x"
+                "eventemitter3": "1.2.0",
+                "requires-port": "1.0.0"
             }
         },
         "http-signature": {
@@ -7164,9 +6954,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.15.2"
             }
         },
         "https-browserify": {
@@ -7181,9 +6971,9 @@
             "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
-                "is-ci": "^1.0.10",
-                "normalize-path": "^1.0.0",
-                "strip-indent": "^2.0.0"
+                "is-ci": "1.2.1",
+                "normalize-path": "1.0.0",
+                "strip-indent": "2.0.0"
             },
             "dependencies": {
                 "normalize-path": {
@@ -7211,7 +7001,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "ieee754": {
@@ -7262,8 +7052,8 @@
             "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
             "dev": true,
             "requires": {
-                "caller-path": "^2.0.0",
-                "resolve-from": "^3.0.0"
+                "caller-path": "2.0.0",
+                "resolve-from": "3.0.0"
             }
         },
         "import-lazy": {
@@ -7290,7 +7080,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "indexof": {
@@ -7310,8 +7100,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -7324,103 +7114,6 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
-        "inquirer": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-            "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^3.0.0",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.10",
-                "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^6.1.0",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^5.0.0",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "ansi-escapes": {
-                    "version": "3.1.0",
-                    "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-                    "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-                    "dev": true
-                },
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "figures": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "^1.0.5"
-                    }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "rxjs": {
-                    "version": "6.3.3",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-                    "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-                    "dev": true,
-                    "requires": {
-                        "tslib": "^1.9.0"
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-                            "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
-                            "dev": true
-                        }
-                    }
-                }
-            }
-        },
         "interpret": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -7432,7 +7125,7 @@
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -7451,8 +7144,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
             }
         },
         "is-accessor-descriptor": {
@@ -7460,7 +7153,7 @@
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7468,7 +7161,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7483,8 +7176,8 @@
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
             "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "requires": {
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0"
+                "is-alphabetical": "1.0.2",
+                "is-decimal": "1.0.2"
             }
         },
         "is-arrayish": {
@@ -7497,7 +7190,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.12.0"
             }
         },
         "is-buffer": {
@@ -7510,7 +7203,7 @@
             "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-callable": {
@@ -7524,7 +7217,7 @@
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "^1.5.0"
+                "ci-info": "1.6.0"
             }
         },
         "is-data-descriptor": {
@@ -7532,7 +7225,7 @@
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7540,7 +7233,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7560,9 +7253,9 @@
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -7590,7 +7283,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -7609,7 +7302,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -7617,7 +7310,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-glob": {
@@ -7625,7 +7318,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "2.1.1"
             }
         },
         "is-hexadecimal": {
@@ -7639,8 +7332,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
             }
         },
         "is-natural-number": {
@@ -7660,7 +7353,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7668,7 +7361,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7679,7 +7372,7 @@
             "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
             "dev": true,
             "requires": {
-                "lodash.isfinite": "^3.3.2"
+                "lodash.isfinite": "3.3.2"
             }
         },
         "is-obj": {
@@ -7694,7 +7387,7 @@
             "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
             "dev": true,
             "requires": {
-                "symbol-observable": "^1.1.0"
+                "symbol-observable": "1.2.0"
             }
         },
         "is-path-cwd": {
@@ -7709,7 +7402,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -7718,7 +7411,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-obj": {
@@ -7731,7 +7424,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -7763,7 +7456,7 @@
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-regexp": {
@@ -7778,14 +7471,8 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "^1.0.0"
+                "is-unc-path": "1.0.0"
             }
-        },
-        "is-resolvable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-            "dev": true
         },
         "is-retry-allowed": {
             "version": "1.1.0",
@@ -7803,7 +7490,7 @@
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -7817,7 +7504,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "^0.1.2"
+                "unc-path-regex": "0.1.2"
             }
         },
         "is-utf8": {
@@ -7856,8 +7543,8 @@
             "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
             "requires": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "3.0.0"
             }
         },
         "isstream": {
@@ -7877,10 +7564,10 @@
             "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^23.6.0"
+                "chalk": "2.4.1",
+                "jest-get-type": "22.4.3",
+                "leven": "2.1.0",
+                "pretty-format": "23.6.0"
             }
         },
         "js-base64": {
@@ -7894,10 +7581,10 @@
             "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.8.tgz",
             "integrity": "sha512-qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==",
             "requires": {
-                "config-chain": "~1.1.5",
-                "editorconfig": "^0.15.0",
-                "mkdirp": "~0.5.0",
-                "nopt": "~4.0.1"
+                "config-chain": "1.1.12",
+                "editorconfig": "0.15.2",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1"
             }
         },
         "js-levenshtein": {
@@ -7917,8 +7604,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -7931,15 +7618,15 @@
             "resolved": "https://registry.npmjs.org/jsdom-no-contextify/-/jsdom-no-contextify-3.1.0.tgz",
             "integrity": "sha1-DYvq9hDC/yOJT1Tfp/id0i/Q96s=",
             "requires": {
-                "browser-request": ">= 0.3.1 < 0.4.0",
-                "cssom": ">= 0.3.0 < 0.4.0",
-                "cssstyle": ">= 0.2.21 < 0.3.0",
-                "htmlparser2": ">= 3.7.3 < 4.0.0",
-                "nwmatcher": ">= 1.3.4 < 2.0.0",
-                "parse5": ">= 1.3.1 < 2.0.0",
-                "request": ">= 2.44.0 < 3.0.0",
-                "xml-name-validator": "^1.0.0",
-                "xmlhttprequest": ">= 1.6.0 < 2.0.0"
+                "browser-request": "0.3.3",
+                "cssom": "0.3.4",
+                "cssstyle": "0.2.37",
+                "htmlparser2": "3.10.0",
+                "nwmatcher": "1.4.4",
+                "parse5": "1.5.1",
+                "request": "2.88.0",
+                "xml-name-validator": "1.0.0",
+                "xmlhttprequest": "1.8.0"
             }
         },
         "jsesc": {
@@ -7963,12 +7650,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -7986,7 +7667,7 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.15"
             }
         },
         "jsonify": {
@@ -8011,7 +7692,7 @@
             "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3"
+                "array-includes": "3.0.3"
             }
         },
         "keygrip": {
@@ -8030,7 +7711,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "^4.0.0"
+                "package-json": "4.0.1"
             }
         },
         "lazy-cache": {
@@ -8045,7 +7726,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lcid": {
@@ -8053,7 +7734,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "less": {
@@ -8062,15 +7743,15 @@
             "integrity": "sha512-8HFGuWmL3FhQR0aH89escFNBQH/nEiYPP2ltDFdQw2chE28Yx2E3lhAIq9Y2saYwLSwa699s4dBVEfCY8Drf7Q==",
             "dev": true,
             "requires": {
-                "clone": "^2.1.2",
-                "errno": "^0.1.1",
-                "graceful-fs": "^4.1.2",
-                "image-size": "~0.5.0",
-                "mime": "^1.4.1",
-                "mkdirp": "^0.5.0",
-                "promise": "^7.1.1",
-                "request": "^2.83.0",
-                "source-map": "~0.6.0"
+                "clone": "2.1.2",
+                "errno": "0.1.7",
+                "graceful-fs": "4.1.15",
+                "image-size": "0.5.5",
+                "mime": "1.4.1",
+                "mkdirp": "0.5.1",
+                "promise": "7.3.1",
+                "request": "2.88.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "clone": {
@@ -8094,30 +7775,20 @@
             "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
             "dev": true
         },
-        "levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            }
-        },
         "liftoff": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
-                "fined": "^1.0.1",
-                "flagged-respawn": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "object.map": "^1.0.0",
-                "rechoir": "^0.6.2",
-                "resolve": "^1.1.7"
+                "extend": "3.0.2",
+                "findup-sync": "2.0.0",
+                "fined": "1.1.0",
+                "flagged-respawn": "1.0.0",
+                "is-plain-object": "2.0.4",
+                "object.map": "1.0.1",
+                "rechoir": "0.6.2",
+                "resolve": "1.8.1"
             }
         },
         "limiter": {
@@ -8132,28 +7803,28 @@
             "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.1",
-                "commander": "^2.14.1",
-                "cosmiconfig": "^5.0.2",
-                "debug": "^3.1.0",
-                "dedent": "^0.7.0",
-                "execa": "^0.9.0",
-                "find-parent-dir": "^0.3.0",
-                "is-glob": "^4.0.0",
-                "is-windows": "^1.0.2",
-                "jest-validate": "^23.5.0",
-                "listr": "^0.14.1",
-                "lodash": "^4.17.5",
-                "log-symbols": "^2.2.0",
-                "micromatch": "^3.1.8",
-                "npm-which": "^3.0.1",
-                "p-map": "^1.1.1",
-                "path-is-inside": "^1.0.2",
-                "pify": "^3.0.0",
-                "please-upgrade-node": "^3.0.2",
+                "chalk": "2.4.1",
+                "commander": "2.19.0",
+                "cosmiconfig": "5.0.7",
+                "debug": "3.2.6",
+                "dedent": "0.7.0",
+                "execa": "0.9.0",
+                "find-parent-dir": "0.3.0",
+                "is-glob": "4.0.0",
+                "is-windows": "1.0.2",
+                "jest-validate": "23.6.0",
+                "listr": "0.14.2",
+                "lodash": "4.17.11",
+                "log-symbols": "2.2.0",
+                "micromatch": "3.1.10",
+                "npm-which": "3.0.1",
+                "p-map": "1.2.0",
+                "path-is-inside": "1.0.2",
+                "pify": "3.0.0",
+                "please-upgrade-node": "3.1.1",
                 "staged-git-files": "1.1.1",
-                "string-argv": "^0.0.2",
-                "stringify-object": "^3.2.2"
+                "string-argv": "0.0.2",
+                "stringify-object": "3.3.0"
             },
             "dependencies": {
                 "debug": {
@@ -8162,7 +7833,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -8179,15 +7850,15 @@
             "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
             "dev": true,
             "requires": {
-                "@samverschueren/stream-to-observable": "^0.3.0",
-                "is-observable": "^1.1.0",
-                "is-promise": "^2.1.0",
-                "is-stream": "^1.1.0",
-                "listr-silent-renderer": "^1.1.1",
-                "listr-update-renderer": "^0.4.0",
-                "listr-verbose-renderer": "^0.4.0",
-                "p-map": "^1.1.1",
-                "rxjs": "^6.1.0"
+                "@samverschueren/stream-to-observable": "0.3.0",
+                "is-observable": "1.1.0",
+                "is-promise": "2.1.0",
+                "is-stream": "1.1.0",
+                "listr-silent-renderer": "1.1.1",
+                "listr-update-renderer": "0.4.0",
+                "listr-verbose-renderer": "0.4.1",
+                "p-map": "1.2.0",
+                "rxjs": "6.3.3"
             },
             "dependencies": {
                 "rxjs": {
@@ -8196,7 +7867,7 @@
                     "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
                     "dev": true,
                     "requires": {
-                        "tslib": "^1.9.0"
+                        "tslib": "1.9.3"
                     }
                 }
             }
@@ -8213,14 +7884,14 @@
             "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "cli-truncate": "^0.2.1",
-                "elegant-spinner": "^1.0.1",
-                "figures": "^1.7.0",
-                "indent-string": "^3.0.0",
-                "log-symbols": "^1.0.2",
-                "log-update": "^1.0.2",
-                "strip-ansi": "^3.0.1"
+                "chalk": "1.1.3",
+                "cli-truncate": "0.2.1",
+                "elegant-spinner": "1.0.1",
+                "figures": "1.7.0",
+                "indent-string": "3.2.0",
+                "log-symbols": "1.0.2",
+                "log-update": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8235,11 +7906,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "indent-string": {
@@ -8254,7 +7925,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.0.0"
+                        "chalk": "1.1.3"
                     }
                 },
                 "supports-color": {
@@ -8271,10 +7942,10 @@
             "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "cli-cursor": "^1.0.2",
-                "date-fns": "^1.27.2",
-                "figures": "^1.7.0"
+                "chalk": "1.1.3",
+                "cli-cursor": "1.0.2",
+                "date-fns": "1.29.0",
+                "figures": "1.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8289,11 +7960,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "cli-cursor": {
@@ -8302,7 +7973,7 @@
                     "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "^1.0.1"
+                        "restore-cursor": "1.0.1"
                     }
                 },
                 "onetime": {
@@ -8317,8 +7988,8 @@
                     "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                     "dev": true,
                     "requires": {
-                        "exit-hook": "^1.0.0",
-                        "onetime": "^1.0.0"
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
                     }
                 },
                 "supports-color": {
@@ -8334,11 +8005,11 @@
             "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.15",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -8360,9 +8031,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
             }
         },
         "localtunnel": {
@@ -8383,8 +8054,8 @@
                     "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
                     "dev": true,
                     "requires": {
-                        "follow-redirects": "^1.2.5",
-                        "is-buffer": "^1.1.5"
+                        "follow-redirects": "1.5.9",
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "camelcase": {
@@ -8405,19 +8076,19 @@
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.2.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "4.2.1"
                     }
                 },
                 "yargs-parser": {
@@ -8426,7 +8097,7 @@
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -8436,8 +8107,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -8543,7 +8214,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "^3.0.0"
+                "lodash._root": "3.0.1"
             }
         },
         "lodash.flatten": {
@@ -8593,9 +8264,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
             }
         },
         "lodash.merge": {
@@ -8634,15 +8305,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
             }
         },
         "lodash.templatesettings": {
@@ -8651,8 +8322,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
             }
         },
         "lodash.toarray": {
@@ -8679,7 +8350,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "2.4.1"
             }
         },
         "log-update": {
@@ -8688,8 +8359,8 @@
             "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^1.0.0",
-                "cli-cursor": "^1.0.2"
+                "ansi-escapes": "1.4.0",
+                "cli-cursor": "1.0.2"
             },
             "dependencies": {
                 "cli-cursor": {
@@ -8698,7 +8369,7 @@
                     "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "^1.0.1"
+                        "restore-cursor": "1.0.1"
                     }
                 },
                 "onetime": {
@@ -8713,8 +8384,8 @@
                     "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                     "dev": true,
                     "requires": {
-                        "exit-hook": "^1.0.0",
-                        "onetime": "^1.0.0"
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
                     }
                 }
             }
@@ -8730,7 +8401,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "4.0.0"
             }
         },
         "loud-rejection": {
@@ -8739,8 +8410,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
             }
         },
         "lowercase-keys": {
@@ -8754,8 +8425,8 @@
             "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
             "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
             "requires": {
-                "fault": "^1.0.2",
-                "highlight.js": "~9.12.0"
+                "fault": "1.0.2",
+                "highlight.js": "9.12.0"
             }
         },
         "lru-cache": {
@@ -8763,8 +8434,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "lru-queue": {
@@ -8773,7 +8444,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.2"
+                "es5-ext": "0.10.46"
             }
         },
         "make-dir": {
@@ -8781,7 +8452,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "make-iterator": {
@@ -8790,7 +8461,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             }
         },
         "map-age-cleaner": {
@@ -8799,7 +8470,7 @@
             "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
             "dev": true,
             "requires": {
-                "p-defer": "^1.0.0"
+                "p-defer": "1.0.0"
             }
         },
         "map-cache": {
@@ -8818,7 +8489,7 @@
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "marked": {
@@ -8838,9 +8509,9 @@
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "mdn-data": {
@@ -8860,9 +8531,9 @@
             "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
             "dev": true,
             "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^1.0.0",
-                "p-is-promise": "^1.1.0"
+                "map-age-cleaner": "0.1.2",
+                "mimic-fn": "1.2.0",
+                "p-is-promise": "1.1.0"
             }
         },
         "memoizee": {
@@ -8871,14 +8542,14 @@
             "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.45",
-                "es6-weak-map": "^2.0.2",
-                "event-emitter": "^0.3.5",
-                "is-promise": "^2.1",
-                "lru-queue": "0.1",
-                "next-tick": "1",
-                "timers-ext": "^0.1.5"
+                "d": "1.0.0",
+                "es5-ext": "0.10.46",
+                "es6-weak-map": "2.0.2",
+                "event-emitter": "0.3.5",
+                "is-promise": "2.1.0",
+                "lru-queue": "0.1.0",
+                "next-tick": "1.0.0",
+                "timers-ext": "0.1.7"
             }
         },
         "memory-fs": {
@@ -8887,8 +8558,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.7",
+                "readable-stream": "2.3.6"
             }
         },
         "memorystream": {
@@ -8902,16 +8573,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
             },
             "dependencies": {
                 "decamelize": {
@@ -8939,7 +8610,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "merge2": {
@@ -8957,19 +8628,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "miller-rabin": {
@@ -8978,8 +8649,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime": {
@@ -8997,7 +8668,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.37.0"
             }
         },
         "mimic-fn": {
@@ -9023,7 +8694,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -9037,16 +8708,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.6.1",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.3",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.3",
+                "through2": "2.0.5"
             }
         },
         "mitt": {
@@ -9060,8 +8731,8 @@
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -9069,7 +8740,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -9092,11 +8763,11 @@
             "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
             "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
             "requires": {
-                "basic-auth": "~2.0.0",
+                "basic-auth": "2.0.1",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "on-headers": "~1.0.1"
+                "depd": "1.1.2",
+                "on-finished": "2.3.0",
+                "on-headers": "1.0.1"
             }
         },
         "move-concurrently": {
@@ -9105,12 +8776,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -9143,29 +8814,23 @@
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "natives": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
             "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-            "dev": true
-        },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
         "ncp": {
@@ -9201,8 +8866,8 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
             }
         },
         "node-gyp": {
@@ -9211,18 +8876,18 @@
             "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
             "dev": true,
             "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.15",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.88.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.1"
             },
             "dependencies": {
                 "nopt": {
@@ -9231,7 +8896,7 @@
                     "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 },
                 "semver": {
@@ -9248,28 +8913,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.2.0",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
-                "https-browserify": "^1.0.0",
-                "os-browserify": "^0.3.0",
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "^0.11.10",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.3.3",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.7.2",
-                "string_decoder": "^1.0.0",
-                "timers-browserify": "^2.0.4",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.3",
+                "string_decoder": "1.1.1",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.10.3",
+                "url": "0.11.0",
+                "util": "0.10.4",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -9285,9 +8950,9 @@
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4",
-                        "isarray": "^1.0.0"
+                        "base64-js": "1.3.0",
+                        "ieee754": "1.1.12",
+                        "isarray": "1.0.0"
                     }
                 },
                 "punycode": {
@@ -9309,7 +8974,7 @@
             "integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
             "dev": true,
             "requires": {
-                "semver": "^5.3.0"
+                "semver": "5.6.0"
             }
         },
         "node-sass": {
@@ -9318,25 +8983,25 @@
             "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
             "dev": true,
             "requires": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^1.1.1",
-                "cross-spawn": "^3.0.0",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
-                "meow": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
-                "node-gyp": "^3.8.0",
-                "npmlog": "^4.0.0",
-                "request": "^2.88.0",
-                "sass-graph": "^2.2.4",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
+                "async-foreach": "0.1.3",
+                "chalk": "1.1.3",
+                "cross-spawn": "3.0.1",
+                "gaze": "1.1.3",
+                "get-stdin": "4.0.1",
+                "glob": "7.1.3",
+                "in-publish": "2.0.0",
+                "lodash.assign": "4.2.0",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.mergewith": "4.6.1",
+                "meow": "3.7.0",
+                "mkdirp": "0.5.1",
+                "nan": "2.11.1",
+                "node-gyp": "3.8.0",
+                "npmlog": "4.1.2",
+                "request": "2.88.0",
+                "sass-graph": "2.2.4",
+                "stdout-stream": "1.4.1",
+                "true-case-path": "1.0.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9351,11 +9016,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -9364,8 +9029,8 @@
                     "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "which": "1.3.1"
                     }
                 },
                 "gaze": {
@@ -9374,7 +9039,7 @@
                     "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
                     "dev": true,
                     "requires": {
-                        "globule": "^1.0.0"
+                        "globule": "1.2.1"
                     }
                 },
                 "globule": {
@@ -9383,9 +9048,9 @@
                     "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
                     "dev": true,
                     "requires": {
-                        "glob": "~7.1.1",
-                        "lodash": "~4.17.10",
-                        "minimatch": "~3.0.2"
+                        "glob": "7.1.3",
+                        "lodash": "4.17.11",
+                        "minimatch": "3.0.4"
                     }
                 },
                 "supports-color": {
@@ -9396,22 +9061,31 @@
                 }
             }
         },
+        "node-sass-tilde-importer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz",
+            "integrity": "sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==",
+            "dev": true,
+            "requires": {
+                "find-parent-dir": "0.3.0"
+            }
+        },
         "nodemon": {
             "version": "1.18.7",
             "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.7.tgz",
             "integrity": "sha512-xuC1V0F5EcEyKQ1VhHYD13owznQbUw29JKvZ8bVH7TmuvVNHvvbp9pLgE4PjTMRJVe0pJ8fGRvwR2nMiosIsPQ==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.4",
-                "debug": "^3.1.0",
-                "ignore-by-default": "^1.0.1",
-                "minimatch": "^3.0.4",
-                "pstree.remy": "^1.1.2",
-                "semver": "^5.5.0",
-                "supports-color": "^5.2.0",
-                "touch": "^3.1.0",
-                "undefsafe": "^2.0.2",
-                "update-notifier": "^2.3.0"
+                "chokidar": "2.0.4",
+                "debug": "3.2.6",
+                "ignore-by-default": "1.0.1",
+                "minimatch": "3.0.4",
+                "pstree.remy": "1.1.2",
+                "semver": "5.6.0",
+                "supports-color": "5.5.0",
+                "touch": "3.1.0",
+                "undefsafe": "2.0.2",
+                "update-notifier": "2.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -9420,7 +9094,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -9436,8 +9110,8 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
             "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
             "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
             }
         },
         "normalize-package-data": {
@@ -9445,10 +9119,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.7.1",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.6.0",
+                "validate-npm-package-license": "3.0.4"
             }
         },
         "normalize-path": {
@@ -9456,7 +9130,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "normalize-range": {
@@ -9471,7 +9145,7 @@
             "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
             "dev": true,
             "requires": {
-                "which": "^1.2.10"
+                "which": "1.3.1"
             }
         },
         "npm-run-all": {
@@ -9479,15 +9153,15 @@
             "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
             "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "chalk": "^2.4.1",
-                "cross-spawn": "^6.0.5",
-                "memorystream": "^0.3.1",
-                "minimatch": "^3.0.4",
-                "pidtree": "^0.3.0",
-                "read-pkg": "^3.0.0",
-                "shell-quote": "^1.6.1",
-                "string.prototype.padend": "^3.0.0"
+                "ansi-styles": "3.2.1",
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
+                "memorystream": "0.3.1",
+                "minimatch": "3.0.4",
+                "pidtree": "0.3.0",
+                "read-pkg": "3.0.0",
+                "shell-quote": "1.6.1",
+                "string.prototype.padend": "3.0.0"
             },
             "dependencies": {
                 "load-json-file": {
@@ -9495,10 +9169,10 @@
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "4.1.15",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "parse-json": {
@@ -9506,8 +9180,8 @@
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "read-pkg": {
@@ -9515,9 +9189,9 @@
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
+                        "load-json-file": "4.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -9533,7 +9207,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "npm-which": {
@@ -9542,9 +9216,9 @@
             "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
             "dev": true,
             "requires": {
-                "commander": "^2.9.0",
-                "npm-path": "^2.0.2",
-                "which": "^1.2.10"
+                "commander": "2.19.0",
+                "npm-path": "2.0.4",
+                "which": "1.3.1"
             }
         },
         "npmlog": {
@@ -9553,10 +9227,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.5",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
             }
         },
         "num2fraction": {
@@ -9596,9 +9270,9 @@
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -9606,7 +9280,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -9614,7 +9288,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -9634,7 +9308,7 @@
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.defaults": {
@@ -9643,10 +9317,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "^1.0.1",
-                "array-slice": "^1.0.0",
-                "for-own": "^1.0.0",
-                "isobject": "^3.0.0"
+                "array-each": "1.0.1",
+                "array-slice": "1.1.0",
+                "for-own": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "for-own": {
@@ -9655,7 +9329,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 }
             }
@@ -9666,8 +9340,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.12.0"
             }
         },
         "object.map": {
@@ -9676,8 +9350,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.1"
             },
             "dependencies": {
                 "for-own": {
@@ -9686,7 +9360,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 }
             }
@@ -9697,8 +9371,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -9706,7 +9380,7 @@
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "on-finished": {
@@ -9727,7 +9401,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -9736,7 +9410,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "openurl": {
@@ -9751,7 +9425,7 @@
             "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
-                "is-wsl": "^1.1.0"
+                "is-wsl": "1.1.0"
             }
         },
         "optimist": {
@@ -9760,30 +9434,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            }
-        },
-        "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-            "dev": true,
-            "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                    "dev": true
-                }
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
             }
         },
         "ora": {
@@ -9792,12 +9444,12 @@
             "integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.1",
-                "cli-cursor": "^2.1.0",
-                "cli-spinners": "^1.1.0",
-                "log-symbols": "^2.2.0",
-                "strip-ansi": "^4.0.0",
-                "wcwidth": "^1.0.1"
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-spinners": "1.3.1",
+                "log-symbols": "2.2.0",
+                "strip-ansi": "4.0.0",
+                "wcwidth": "1.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -9812,7 +9464,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -9823,9 +9475,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "end-of-stream": "0.1.5",
+                "sequencify": "0.0.7",
+                "stream-consume": "0.1.1"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -9834,7 +9486,7 @@
                     "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
                     "dev": true,
                     "requires": {
-                        "once": "~1.3.0"
+                        "once": "1.3.3"
                     }
                 },
                 "once": {
@@ -9843,7 +9495,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 }
             }
@@ -9870,7 +9522,7 @@
             "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
             }
         },
         "os-tmpdir": {
@@ -9883,8 +9535,8 @@
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "output-file-sync": {
@@ -9892,9 +9544,9 @@
             "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
             "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "is-plain-obj": "^1.1.0",
-                "mkdirp": "^0.5.1"
+                "graceful-fs": "4.1.15",
+                "is-plain-obj": "1.1.0",
+                "mkdirp": "0.5.1"
             }
         },
         "p-defer": {
@@ -9920,7 +9572,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -9928,7 +9580,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.3.0"
             }
         },
         "p-map": {
@@ -9954,10 +9606,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "^6.7.1",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
+                "got": "6.7.1",
+                "registry-auth-token": "3.3.2",
+                "registry-url": "3.1.0",
+                "semver": "5.6.0"
             }
         },
         "pako": {
@@ -9972,9 +9624,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "parse": {
@@ -9982,9 +9634,9 @@
             "resolved": "http://registry.npmjs.org/parse/-/parse-1.11.1.tgz",
             "integrity": "sha1-VY5TnULZ+4khDggiCdbzsD1frtU=",
             "requires": {
-                "babel-runtime": "^6.11.6",
-                "ws": "^3.3.1",
-                "xmlhttprequest": "^1.7.0"
+                "babel-runtime": "6.26.0",
+                "ws": "3.3.3",
+                "xmlhttprequest": "1.8.0"
             }
         },
         "parse-asn1": {
@@ -9993,11 +9645,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.17"
             }
         },
         "parse-entities": {
@@ -10005,12 +9657,12 @@
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
             "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
             "requires": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
+                "character-entities": "1.2.2",
+                "character-entities-legacy": "1.1.2",
+                "character-reference-invalid": "1.1.2",
+                "is-alphanumerical": "1.0.2",
+                "is-decimal": "1.0.2",
+                "is-hexadecimal": "1.0.2"
             }
         },
         "parse-filepath": {
@@ -10019,9 +9671,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "^1.0.0",
-                "map-cache": "^0.2.0",
-                "path-root": "^0.1.1"
+                "is-absolute": "1.0.0",
+                "map-cache": "0.2.2",
+                "path-root": "0.1.1"
             }
         },
         "parse-glob": {
@@ -10030,10 +9682,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -10048,7 +9700,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -10058,7 +9710,7 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.2"
             }
         },
         "parse-key": {
@@ -10082,7 +9734,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseuri": {
@@ -10091,7 +9743,7 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseurl": {
@@ -10148,7 +9800,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "^0.1.0"
+                "path-root-regex": "0.1.2"
             }
         },
         "path-root-regex": {
@@ -10167,7 +9819,7 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "pbkdf2": {
@@ -10176,11 +9828,11 @@
             "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
             "dev": true,
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "pend": {
@@ -10214,7 +9866,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pirates": {
@@ -10222,7 +9874,7 @@
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
             "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
             "requires": {
-                "node-modules-regexp": "^1.0.0"
+                "node-modules-regexp": "1.0.0"
             }
         },
         "pkg-conf": {
@@ -10230,10 +9882,10 @@
             "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
             "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
             "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.1",
+                "symbol": "0.2.3"
             },
             "dependencies": {
                 "find-up": {
@@ -10241,8 +9893,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-exists": {
@@ -10250,7 +9902,7 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 }
             }
@@ -10260,7 +9912,7 @@
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             }
         },
         "pkg-up": {
@@ -10269,7 +9921,7 @@
             "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             }
         },
         "pkginfo": {
@@ -10284,7 +9936,7 @@
             "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
             "dev": true,
             "requires": {
-                "semver-compare": "^1.0.0"
+                "semver-compare": "1.0.0"
             }
         },
         "plugin-error": {
@@ -10293,17 +9945,11 @@
             "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "^1.0.1",
-                "arr-diff": "^4.0.0",
-                "arr-union": "^3.1.0",
-                "extend-shallow": "^3.0.2"
+                "ansi-colors": "1.1.0",
+                "arr-diff": "4.0.0",
+                "arr-union": "3.1.0",
+                "extend-shallow": "3.0.2"
             }
-        },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
         },
         "portscanner": {
             "version": "2.1.1",
@@ -10312,7 +9958,7 @@
             "dev": true,
             "requires": {
                 "async": "1.5.2",
-                "is-number-like": "^1.0.3"
+                "is-number-like": "1.0.8"
             },
             "dependencies": {
                 "async": {
@@ -10334,9 +9980,9 @@
             "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
+                "chalk": "2.4.1",
+                "source-map": "0.6.1",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "source-map": {
@@ -10351,12 +9997,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
             "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-            "dev": true
-        },
-        "prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
         "prepend-http": {
@@ -10382,8 +10022,8 @@
             "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
+                "ansi-regex": "3.0.0",
+                "ansi-styles": "3.2.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10405,7 +10045,7 @@
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
             "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
             "requires": {
-                "clipboard": "^2.0.0"
+                "clipboard": "2.0.3"
             }
         },
         "private": {
@@ -10425,18 +10065,12 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
-        "progress": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.2.tgz",
-            "integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==",
-            "dev": true
-        },
         "promise": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "requires": {
-                "asap": "~2.0.3"
+                "asap": "2.0.6"
             }
         },
         "promise-inflight": {
@@ -10451,12 +10085,12 @@
             "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
             "dev": true,
             "requires": {
-                "colors": "^1.1.2",
-                "pkginfo": "0.x.x",
-                "read": "1.0.x",
-                "revalidator": "0.1.x",
-                "utile": "0.3.x",
-                "winston": "2.1.x"
+                "colors": "1.3.2",
+                "pkginfo": "0.4.1",
+                "read": "1.0.7",
+                "revalidator": "0.1.8",
+                "utile": "0.3.0",
+                "winston": "2.1.1"
             }
         },
         "prop-types": {
@@ -10464,8 +10098,8 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
             "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
             "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
             }
         },
         "property-information": {
@@ -10473,7 +10107,7 @@
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
             "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
             "requires": {
-                "xtend": "^4.0.1"
+                "xtend": "4.0.1"
             }
         },
         "proto-list": {
@@ -10486,7 +10120,7 @@
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "requires": {
-                "forwarded": "~0.1.2",
+                "forwarded": "0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -10518,12 +10152,12 @@
             "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.1",
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "pump": {
@@ -10532,8 +10166,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -10542,9 +10176,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.1",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -10585,9 +10219,9 @@
             "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -10604,7 +10238,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -10613,8 +10247,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "range-parser": {
@@ -10639,10 +10273,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.6.0",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -10658,10 +10292,10 @@
             "resolved": "https://registry.npmjs.org/react/-/react-16.6.1.tgz",
             "integrity": "sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==",
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.11.0"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "scheduler": "0.11.0"
             }
         },
         "react-base16-styling": {
@@ -10669,10 +10303,10 @@
             "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",
             "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
             "requires": {
-                "base16": "^1.0.0",
-                "lodash.curry": "^4.0.1",
-                "lodash.flow": "^3.3.0",
-                "pure-color": "^1.2.0"
+                "base16": "1.0.0",
+                "lodash.curry": "4.1.1",
+                "lodash.flow": "3.5.0",
+                "pure-color": "1.3.0"
             }
         },
         "react-dock": {
@@ -10680,8 +10314,8 @@
             "resolved": "https://registry.npmjs.org/react-dock/-/react-dock-0.2.4.tgz",
             "integrity": "sha1-5yfcdVCztzEWY13LnA4E0Lev4Xw=",
             "requires": {
-                "lodash.debounce": "^3.1.1",
-                "prop-types": "^15.5.8"
+                "lodash.debounce": "3.1.1",
+                "prop-types": "15.6.2"
             },
             "dependencies": {
                 "lodash.debounce": {
@@ -10689,7 +10323,7 @@
                     "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
                     "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
                     "requires": {
-                        "lodash._getnative": "^3.0.0"
+                        "lodash._getnative": "3.9.1"
                     }
                 }
             }
@@ -10699,10 +10333,10 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.1.tgz",
             "integrity": "sha512-zm+wBuEMGm009Wt1uE4Zw5KcXOW7qC4E/xW/fpJsCsbOco4U/R84u+DzzO/S4SYSdNBcqcaulcp4w3FXl8pImw==",
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.11.0"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "scheduler": "0.11.0"
             }
         },
         "react-frame-component": {
@@ -10715,10 +10349,10 @@
             "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
             "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
             "requires": {
-                "deep-equal": "^1.0.1",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.5.4",
-                "react-side-effect": "^1.1.0"
+                "deep-equal": "1.0.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "react-side-effect": "1.1.5"
             }
         },
         "react-is": {
@@ -10731,9 +10365,9 @@
             "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.11.0.tgz",
             "integrity": "sha1-9bF+gzKanHauOL5cBP2jp/1oSjU=",
             "requires": {
-                "babel-runtime": "^6.6.1",
-                "prop-types": "^15.5.8",
-                "react-base16-styling": "^0.5.1"
+                "babel-runtime": "6.26.0",
+                "prop-types": "15.6.2",
+                "react-base16-styling": "0.5.3"
             }
         },
         "react-lifecycles-compat": {
@@ -10751,13 +10385,13 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
             "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
             "requires": {
-                "@babel/runtime": "^7.1.2",
-                "hoist-non-react-statics": "^3.1.0",
-                "invariant": "^2.2.4",
-                "loose-envify": "^1.1.0",
-                "prop-types": "^15.6.1",
-                "react-is": "^16.6.0",
-                "react-lifecycles-compat": "^3.0.0"
+                "@babel/runtime": "7.1.5",
+                "hoist-non-react-statics": "3.1.0",
+                "invariant": "2.2.4",
+                "loose-envify": "1.4.0",
+                "prop-types": "15.6.2",
+                "react-is": "16.6.1",
+                "react-lifecycles-compat": "3.0.4"
             }
         },
         "react-router": {
@@ -10765,13 +10399,13 @@
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
             "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
             "requires": {
-                "history": "^4.7.2",
-                "hoist-non-react-statics": "^2.5.0",
-                "invariant": "^2.2.4",
-                "loose-envify": "^1.3.1",
-                "path-to-regexp": "^1.7.0",
-                "prop-types": "^15.6.1",
-                "warning": "^4.0.1"
+                "history": "4.7.2",
+                "hoist-non-react-statics": "2.5.5",
+                "invariant": "2.2.4",
+                "loose-envify": "1.4.0",
+                "path-to-regexp": "1.7.0",
+                "prop-types": "15.6.2",
+                "warning": "4.0.2"
             },
             "dependencies": {
                 "hoist-non-react-statics": {
@@ -10804,12 +10438,12 @@
             "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
             "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
             "requires": {
-                "history": "^4.7.2",
-                "invariant": "^2.2.4",
-                "loose-envify": "^1.3.1",
-                "prop-types": "^15.6.1",
-                "react-router": "^4.3.1",
-                "warning": "^4.0.1"
+                "history": "4.7.2",
+                "invariant": "2.2.4",
+                "loose-envify": "1.4.0",
+                "prop-types": "15.6.2",
+                "react-router": "4.3.1",
+                "warning": "4.0.2"
             }
         },
         "react-side-effect": {
@@ -10817,8 +10451,8 @@
             "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
             "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
             "requires": {
-                "exenv": "^1.2.1",
-                "shallowequal": "^1.0.1"
+                "exenv": "1.2.2",
+                "shallowequal": "1.1.0"
             }
         },
         "react-syntax-highlighter": {
@@ -10826,11 +10460,11 @@
             "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-8.1.0.tgz",
             "integrity": "sha512-G2bkZxmF3VOa4atEdXIDSfwwCqjw6ZQX5znfTaHcErA1WqHIS0o6DaSCDKFPVaOMXQEB9Hf1UySYQvuJmV8CXg==",
             "requires": {
-                "babel-runtime": "^6.18.0",
-                "highlight.js": "~9.12.0",
-                "lowlight": "~1.9.1",
-                "prismjs": "^1.8.4",
-                "refractor": "^2.4.1"
+                "babel-runtime": "6.26.0",
+                "highlight.js": "9.12.0",
+                "lowlight": "1.9.2",
+                "prismjs": "1.15.0",
+                "refractor": "2.6.1"
             }
         },
         "read": {
@@ -10839,7 +10473,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "~0.0.4"
+                "mute-stream": "0.0.7"
             }
         },
         "read-pkg": {
@@ -10847,9 +10481,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             },
             "dependencies": {
                 "path-type": {
@@ -10857,9 +10491,9 @@
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.15",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "pify": {
@@ -10874,8 +10508,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -10883,8 +10517,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-exists": {
@@ -10892,7 +10526,7 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 }
             }
@@ -10902,13 +10536,13 @@
             "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "readdir-recursive": {
@@ -10922,9 +10556,9 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "micromatch": "^3.1.10",
-                "readable-stream": "^2.0.2"
+                "graceful-fs": "4.1.15",
+                "micromatch": "3.1.10",
+                "readable-stream": "2.3.6"
             }
         },
         "rechoir": {
@@ -10933,7 +10567,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.8.1"
             }
         },
         "redbox-react": {
@@ -10941,10 +10575,10 @@
             "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.6.0.tgz",
             "integrity": "sha512-mLjM5eYR41yOp5YKHpd3syFeGq6B4Wj5vZr64nbLvTZW5ZLff4LYk7VE4ITpVxkZpCY6OZuqh0HiP3A3uEaCpg==",
             "requires": {
-                "error-stack-parser": "^1.3.6",
-                "object-assign": "^4.0.1",
-                "prop-types": "^15.5.4",
-                "sourcemapped-stacktrace": "^1.1.6"
+                "error-stack-parser": "1.3.6",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "sourcemapped-stacktrace": "1.1.9"
             }
         },
         "redent": {
@@ -10953,8 +10587,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
             }
         },
         "redux": {
@@ -10962,8 +10596,8 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
             "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
             "requires": {
-                "loose-envify": "^1.4.0",
-                "symbol-observable": "^1.2.0"
+                "loose-envify": "1.4.0",
+                "symbol-observable": "1.2.0"
             }
         },
         "redux-devtools": {
@@ -10971,9 +10605,9 @@
             "resolved": "https://registry.npmjs.org/redux-devtools/-/redux-devtools-3.4.1.tgz",
             "integrity": "sha1-CdNCzgq2CHvmeelTodfFMO+hE44=",
             "requires": {
-                "lodash": "^4.2.0",
-                "prop-types": "^15.5.7",
-                "redux-devtools-instrument": "^1.0.1"
+                "lodash": "4.17.11",
+                "prop-types": "15.6.2",
+                "redux-devtools-instrument": "1.9.0"
             }
         },
         "redux-devtools-dock-monitor": {
@@ -10981,11 +10615,11 @@
             "resolved": "https://registry.npmjs.org/redux-devtools-dock-monitor/-/redux-devtools-dock-monitor-1.1.3.tgz",
             "integrity": "sha512-yAXzoI0lpjv19CxVuw8RECeFWUVdyzayqnkX8ePZyeXV2ZgIk4T+rKx82Wk+REP1y3rl8o1/oFDq4B7EobOqMg==",
             "requires": {
-                "babel-runtime": "^6.2.0",
-                "parse-key": "^0.2.1",
-                "prop-types": "^15.5.8",
-                "react-dock": "^0.2.4",
-                "react-pure-render": "^1.0.2"
+                "babel-runtime": "6.26.0",
+                "parse-key": "0.2.1",
+                "prop-types": "15.6.2",
+                "react-dock": "0.2.4",
+                "react-pure-render": "1.0.2"
             }
         },
         "redux-devtools-instrument": {
@@ -10993,8 +10627,8 @@
             "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.0.tgz",
             "integrity": "sha512-pLFQoja1ojpsSRTWbC9yyc/a+z8uwOD7FPKLp+Abs7qjsah6khA5o8HBE2wa0VipE5vniYINdkNyxV/2iWADKg==",
             "requires": {
-                "lodash": "^4.2.0",
-                "symbol-observable": "^1.0.2"
+                "lodash": "4.17.11",
+                "symbol-observable": "1.2.0"
             }
         },
         "redux-devtools-log-monitor": {
@@ -11002,11 +10636,11 @@
             "resolved": "https://registry.npmjs.org/redux-devtools-log-monitor/-/redux-devtools-log-monitor-1.4.0.tgz",
             "integrity": "sha1-cWuVgO2iozHNNZo2qgnjoWAqhUs=",
             "requires": {
-                "lodash.debounce": "^4.0.4",
-                "prop-types": "^15.0.0",
-                "react-json-tree": "^0.11.0",
-                "react-pure-render": "^1.0.2",
-                "redux-devtools-themes": "^1.0.0"
+                "lodash.debounce": "4.0.8",
+                "prop-types": "15.6.2",
+                "react-json-tree": "0.11.0",
+                "react-pure-render": "1.0.2",
+                "redux-devtools-themes": "1.0.0"
             }
         },
         "redux-devtools-themes": {
@@ -11014,7 +10648,7 @@
             "resolved": "https://registry.npmjs.org/redux-devtools-themes/-/redux-devtools-themes-1.0.0.tgz",
             "integrity": "sha1-xILc48U3OXYEX0ATSQfZ3LOuPV0=",
             "requires": {
-                "base16": "^1.0.0"
+                "base16": "1.0.0"
             }
         },
         "redux-local-persist": {
@@ -11022,9 +10656,9 @@
             "resolved": "https://registry.npmjs.org/redux-local-persist/-/redux-local-persist-0.0.5.tgz",
             "integrity": "sha1-rDbblmzHcf0ISER3W6h66cJgvNE=",
             "requires": {
-                "moment": "^2.22.1",
-                "object-path": "^0.11.4",
-                "underscore": "^1.9.0"
+                "moment": "2.22.2",
+                "object-path": "0.11.4",
+                "underscore": "1.9.1"
             }
         },
         "redux-super-thunk": {
@@ -11037,9 +10671,9 @@
             "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.6.1.tgz",
             "integrity": "sha512-tdRAsgmoNw8BKsCD9lQkLnCXVBnhtYU254VNXJQ1n6cDd9Dw+vaofGjt507Hymwpy7BhhySyc/sEtiL6Q2G7KA==",
             "requires": {
-                "hastscript": "^4.0.0",
-                "parse-entities": "^1.1.2",
-                "prismjs": "~1.15.0"
+                "hastscript": "4.1.0",
+                "parse-entities": "1.2.0",
+                "prismjs": "1.15.0"
             }
         },
         "regenerate": {
@@ -11054,7 +10688,7 @@
             "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0"
+                "regenerate": "1.4.0"
             }
         },
         "regenerator-runtime": {
@@ -11068,7 +10702,7 @@
             "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
             "dev": true,
             "requires": {
-                "private": "^0.1.6"
+                "private": "0.1.8"
             }
         },
         "regex-cache": {
@@ -11077,7 +10711,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -11085,15 +10719,9 @@
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
-        },
-        "regexpp": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-            "dev": true
         },
         "regexpu-core": {
             "version": "4.2.0",
@@ -11101,12 +10729,12 @@
             "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0",
-                "regenerate-unicode-properties": "^7.0.0",
-                "regjsgen": "^0.4.0",
-                "regjsparser": "^0.3.0",
-                "unicode-match-property-ecmascript": "^1.0.4",
-                "unicode-match-property-value-ecmascript": "^1.0.2"
+                "regenerate": "1.4.0",
+                "regenerate-unicode-properties": "7.0.0",
+                "regjsgen": "0.4.0",
+                "regjsparser": "0.3.0",
+                "unicode-match-property-ecmascript": "1.0.4",
+                "unicode-match-property-value-ecmascript": "1.0.2"
             }
         },
         "registry-auth-token": {
@@ -11115,8 +10743,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
+                "rc": "1.2.8",
+                "safe-buffer": "5.1.2"
             }
         },
         "registry-url": {
@@ -11125,7 +10753,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "^1.0.1"
+                "rc": "1.2.8"
             }
         },
         "regjsgen": {
@@ -11140,7 +10768,7 @@
             "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
             "dev": true,
             "requires": {
-                "jsesc": "~0.5.0"
+                "jsesc": "0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -11172,7 +10800,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "replace-ext": {
@@ -11186,26 +10814,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.21",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "require-directory": {
@@ -11218,39 +10846,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "require-uncached": {
-            "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true,
-            "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
-            },
-            "dependencies": {
-                "caller-path": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-                    "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-                    "dev": true,
-                    "requires": {
-                        "callsites": "^0.2.0"
-                    }
-                },
-                "callsites": {
-                    "version": "0.2.0",
-                    "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                    "dev": true
-                },
-                "resolve-from": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-                    "dev": true
-                }
-            }
         },
         "requires-port": {
             "version": "1.0.0",
@@ -11270,7 +10865,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.6"
             }
         },
         "resolve-dir": {
@@ -11279,8 +10874,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
             }
         },
         "resolve-from": {
@@ -11305,8 +10900,8 @@
             "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
             "dev": true,
             "requires": {
-                "debug": "^2.2.0",
-                "minimatch": "^3.0.2"
+                "debug": "2.6.9",
+                "minimatch": "3.0.4"
             }
         },
         "restore-cursor": {
@@ -11315,8 +10910,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -11336,7 +10931,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "^0.1.1"
+                "align-text": "0.1.4"
             }
         },
         "rimraf": {
@@ -11345,7 +10940,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.3"
             }
         },
         "ripemd160": {
@@ -11354,17 +10949,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
-            }
-        },
-        "run-async": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "dev": true,
-            "requires": {
-                "is-promise": "^2.1.0"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "run-queue": {
@@ -11373,7 +10959,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "run-sequence": {
@@ -11382,9 +10968,9 @@
             "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "fancy-log": "^1.3.2",
-                "plugin-error": "^0.1.2"
+                "chalk": "1.1.3",
+                "fancy-log": "1.3.2",
+                "plugin-error": "0.1.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11399,8 +10985,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
                     }
                 },
                 "arr-union": {
@@ -11421,11 +11007,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -11434,7 +11020,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^1.1.0"
+                        "kind-of": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -11449,11 +11035,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "^0.1.1",
-                        "ansi-red": "^0.1.1",
-                        "arr-diff": "^1.0.1",
-                        "arr-union": "^2.0.1",
-                        "extend-shallow": "^1.1.2"
+                        "ansi-cyan": "0.1.1",
+                        "ansi-red": "0.1.1",
+                        "arr-diff": "1.1.0",
+                        "arr-union": "2.1.0",
+                        "extend-shallow": "1.1.4"
                     }
                 },
                 "supports-color": {
@@ -11497,7 +11083,7 @@
             "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -11511,10 +11097,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "lodash": "^4.0.0",
-                "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
+                "glob": "7.1.3",
+                "lodash": "4.17.11",
+                "scss-tokenizer": "0.2.3",
+                "yargs": "7.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -11535,19 +11121,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -11556,7 +11142,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -11566,8 +11152,8 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.0.tgz",
             "integrity": "sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==",
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
             }
         },
         "schema-utils": {
@@ -11576,8 +11162,8 @@
             "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.5.5",
+                "ajv-keywords": "3.2.0"
             }
         },
         "scss-tokenizer": {
@@ -11586,8 +11172,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "^2.1.8",
-                "source-map": "^0.4.2"
+                "js-base64": "2.4.9",
+                "source-map": "0.4.4"
             },
             "dependencies": {
                 "source-map": {
@@ -11596,7 +11182,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -11607,7 +11193,7 @@
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
             "requires": {
-                "commander": "~2.8.1"
+                "commander": "2.8.1"
             },
             "dependencies": {
                 "commander": {
@@ -11616,7 +11202,7 @@
                     "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": ">= 1.0.0"
+                        "graceful-readlink": "1.0.1"
                     }
                 }
             }
@@ -11644,7 +11230,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "^5.0.3"
+                "semver": "5.6.0"
             }
         },
         "send": {
@@ -11653,18 +11239,18 @@
             "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
             "requires": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
+                "http-errors": "1.6.3",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
             },
             "dependencies": {
                 "statuses": {
@@ -11691,13 +11277,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.4",
+                "accepts": "1.3.5",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.6.2",
-                "mime-types": "~2.1.17",
-                "parseurl": "~1.3.2"
+                "escape-html": "1.0.3",
+                "http-errors": "1.6.3",
+                "mime-types": "2.1.21",
+                "parseurl": "1.3.2"
             }
         },
         "serve-static": {
@@ -11705,9 +11291,9 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -11728,10 +11314,10 @@
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -11739,7 +11325,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -11760,8 +11346,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "shallowequal": {
@@ -11774,7 +11360,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -11787,10 +11373,10 @@
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "requires": {
-                "array-filter": "~0.0.0",
-                "array-map": "~0.0.0",
-                "array-reduce": "~0.0.0",
-                "jsonify": "~0.0.0"
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
             }
         },
         "sigmund": {
@@ -11826,14 +11412,14 @@
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -11841,7 +11427,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -11849,7 +11435,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -11859,9 +11445,9 @@
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -11869,7 +11455,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -11877,7 +11463,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -11885,7 +11471,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -11893,9 +11479,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -11905,7 +11491,7 @@
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -11913,7 +11499,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -11924,12 +11510,12 @@
             "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
             "dev": true,
             "requires": {
-                "debug": "~3.1.0",
-                "engine.io": "~3.2.0",
-                "has-binary2": "~1.0.2",
-                "socket.io-adapter": "~1.1.0",
+                "debug": "3.1.0",
+                "engine.io": "3.2.1",
+                "has-binary2": "1.0.3",
+                "socket.io-adapter": "1.1.1",
                 "socket.io-client": "2.1.1",
-                "socket.io-parser": "~3.2.0"
+                "socket.io-parser": "3.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -11959,15 +11545,15 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
-                "engine.io-client": "~3.2.0",
-                "has-binary2": "~1.0.2",
+                "debug": "3.1.0",
+                "engine.io-client": "3.2.1",
+                "has-binary2": "1.0.3",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.2.0",
+                "socket.io-parser": "3.2.0",
                 "to-array": "0.1.4"
             },
             "dependencies": {
@@ -11989,7 +11575,7 @@
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
+                "debug": "3.1.0",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -12026,11 +11612,11 @@
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -12038,8 +11624,8 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -12088,8 +11674,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
             "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.2"
             }
         },
         "spdx-exceptions": {
@@ -12102,8 +11688,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.2"
             }
         },
         "spdx-license-ids": {
@@ -12116,7 +11702,7 @@
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -12130,15 +11716,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
             "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -12147,7 +11733,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stack-trace": {
@@ -12172,8 +11758,8 @@
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -12181,7 +11767,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -12197,7 +11783,7 @@
             "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "stream-browserify": {
@@ -12206,8 +11792,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "stream-consume": {
@@ -12222,8 +11808,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
             }
         },
         "stream-http": {
@@ -12232,11 +11818,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
             }
         },
         "stream-shift": {
@@ -12251,8 +11837,8 @@
             "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
             "dev": true,
             "requires": {
-                "commander": "^2.2.0",
-                "limiter": "^1.0.5"
+                "commander": "2.19.0",
+                "limiter": "1.1.3"
             }
         },
         "string-argv": {
@@ -12266,9 +11852,9 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "string.prototype.padend": {
@@ -12276,9 +11862,9 @@
             "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
             "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.4.3",
-                "function-bind": "^1.0.2"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.12.0",
+                "function-bind": "1.1.1"
             }
         },
         "string_decoder": {
@@ -12286,7 +11872,7 @@
             "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "stringify-object": {
@@ -12295,9 +11881,9 @@
             "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
             "dev": true,
             "requires": {
-                "get-own-enumerable-property-symbols": "^3.0.0",
-                "is-obj": "^1.0.1",
-                "is-regexp": "^1.0.0"
+                "get-own-enumerable-property-symbols": "3.0.0",
+                "is-obj": "1.0.1",
+                "is-regexp": "1.0.0"
             }
         },
         "strip-ansi": {
@@ -12305,7 +11891,7 @@
             "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -12313,7 +11899,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-bom-stream": {
@@ -12322,8 +11908,8 @@
             "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "2.0.0",
+                "strip-bom": "2.0.0"
             },
             "dependencies": {
                 "first-chunk-stream": {
@@ -12332,7 +11918,7 @@
                     "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.0.2"
+                        "readable-stream": "2.3.6"
                     }
                 }
             }
@@ -12349,7 +11935,7 @@
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
             "requires": {
-                "is-natural-number": "^4.0.1"
+                "is-natural-number": "4.0.1"
             }
         },
         "strip-eof": {
@@ -12364,7 +11950,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "^4.0.1"
+                "get-stdin": "4.0.1"
             }
         },
         "strip-json-comments": {
@@ -12378,7 +11964,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "symbol": {
@@ -12390,74 +11976,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
             "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        },
-        "table": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
-            "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.6.1",
-                "lodash": "^4.17.11",
-                "slice-ansi": "2.0.0",
-                "string-width": "^2.1.1"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-                    "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "slice-ansi": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-                    "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "astral-regex": "^1.0.0",
-                        "is-fullwidth-code-point": "^2.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
         },
         "tapable": {
             "version": "1.1.0",
@@ -12471,9 +11989,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "tar-stream": {
@@ -12482,13 +12000,13 @@
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
             "requires": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.2.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.1",
-                "xtend": "^4.0.0"
+                "bl": "1.2.2",
+                "buffer-alloc": "1.2.0",
+                "end-of-stream": "1.4.1",
+                "fs-constants": "1.0.0",
+                "readable-stream": "2.3.6",
+                "to-buffer": "1.1.1",
+                "xtend": "4.0.1"
             }
         },
         "term-size": {
@@ -12497,7 +12015,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "^0.7.0"
+                "execa": "0.7.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -12506,9 +12024,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "execa": {
@@ -12517,13 +12035,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     }
                 },
                 "get-stream": {
@@ -12540,17 +12058,11 @@
             "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
             "dev": true,
             "requires": {
-                "duplexify": "^3.5.0",
-                "fork-stream": "^0.0.4",
-                "merge-stream": "^1.0.0",
-                "through2": "^2.0.1"
+                "duplexify": "3.6.1",
+                "fork-stream": "0.0.4",
+                "merge-stream": "1.0.1",
+                "through2": "2.0.5"
             }
-        },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
         },
         "tfunk": {
             "version": "3.1.0",
@@ -12558,8 +12070,8 @@
             "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.1",
-                "object-path": "^0.9.0"
+                "chalk": "1.1.3",
+                "object-path": "0.9.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12574,11 +12086,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "object-path": {
@@ -12607,8 +12119,8 @@
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "tildify": {
@@ -12617,7 +12129,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "os-homedir": "1.0.2"
             }
         },
         "time-stamp": {
@@ -12638,7 +12150,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "timers-ext": {
@@ -12647,8 +12159,8 @@
             "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.46",
-                "next-tick": "1"
+                "es5-ext": "0.10.46",
+                "next-tick": "1.0.0"
             }
         },
         "tiny-emitter": {
@@ -12656,15 +12168,6 @@
             "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
             "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
             "optional": true
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
         },
         "to-array": {
             "version": "0.1.4",
@@ -12695,7 +12198,7 @@
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -12703,7 +12206,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -12713,10 +12216,10 @@
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -12724,8 +12227,8 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "toggle-selection": {
@@ -12739,7 +12242,7 @@
             "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
             "dev": true,
             "requires": {
-                "nopt": "~1.0.10"
+                "nopt": "1.0.10"
             },
             "dependencies": {
                 "nopt": {
@@ -12748,7 +12251,7 @@
                     "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 }
             }
@@ -12758,8 +12261,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "1.1.29",
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -12792,7 +12295,7 @@
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.2"
+                "glob": "7.1.3"
             }
         },
         "tslib": {
@@ -12812,7 +12315,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -12820,22 +12323,13 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
-        "type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "~1.1.2"
-            }
-        },
         "type-is": {
             "version": "1.6.16",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
             "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
+                "mime-types": "2.1.21"
             }
         },
         "typedarray": {
@@ -12856,8 +12350,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.17.1",
-                "source-map": "~0.6.1"
+                "commander": "2.17.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -12889,14 +12383,14 @@
             "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
             "dev": true,
             "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "schema-utils": "^0.4.5",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-es": "^3.3.4",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "schema-utils": "0.4.7",
+                "serialize-javascript": "1.5.0",
+                "source-map": "0.6.1",
+                "uglify-es": "3.3.9",
+                "webpack-sources": "1.3.0",
+                "worker-farm": "1.6.0"
             },
             "dependencies": {
                 "commander": {
@@ -12917,8 +12411,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.13.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.13.0",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -12934,8 +12428,8 @@
             "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
             "dev": true,
             "requires": {
-                "buffer": "^3.0.1",
-                "through": "^2.3.6"
+                "buffer": "3.6.0",
+                "through": "2.3.8"
             }
         },
         "unc-path-regex": {
@@ -12950,7 +12444,7 @@
             "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
             "dev": true,
             "requires": {
-                "debug": "^2.2.0"
+                "debug": "2.6.9"
             }
         },
         "underscore": {
@@ -12970,8 +12464,8 @@
             "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
             "dev": true,
             "requires": {
-                "unicode-canonical-property-names-ecmascript": "^1.0.4",
-                "unicode-property-aliases-ecmascript": "^1.0.4"
+                "unicode-canonical-property-names-ecmascript": "1.0.4",
+                "unicode-property-aliases-ecmascript": "1.0.4"
             }
         },
         "unicode-match-property-value-ecmascript": {
@@ -12991,10 +12485,10 @@
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -13002,7 +12496,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -13010,10 +12504,10 @@
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -13024,7 +12518,7 @@
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "dev": true,
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.1"
             }
         },
         "unique-slug": {
@@ -13033,7 +12527,7 @@
             "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
             "dev": true,
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "unique-stream": {
@@ -13048,7 +12542,7 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "^1.0.0"
+                "crypto-random-string": "1.0.0"
             }
         },
         "universalify": {
@@ -13072,8 +12566,8 @@
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -13081,9 +12575,9 @@
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -13120,16 +12614,16 @@
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "dev": true,
             "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.3.0",
+                "chalk": "2.4.1",
+                "configstore": "3.1.2",
+                "import-lazy": "2.1.0",
+                "is-ci": "1.2.1",
+                "is-installed-globally": "0.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
             }
         },
         "uri-js": {
@@ -13137,7 +12631,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "urix": {
@@ -13169,7 +12663,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "^1.0.1"
+                "prepend-http": "1.0.4"
             }
         },
         "use": {
@@ -13203,8 +12697,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "utile": {
@@ -13213,12 +12707,12 @@
             "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
             "dev": true,
             "requires": {
-                "async": "~0.9.0",
-                "deep-equal": "~0.2.1",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "1.0.x",
-                "rimraf": "2.x.x"
+                "async": "0.9.2",
+                "deep-equal": "0.2.2",
+                "i": "0.3.6",
+                "mkdirp": "0.5.1",
+                "ncp": "1.0.1",
+                "rimraf": "2.6.2"
             },
             "dependencies": {
                 "async": {
@@ -13250,7 +12744,7 @@
             "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
             "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -13258,8 +12752,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.0.2",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "value-equal": {
@@ -13277,9 +12771,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -13288,8 +12782,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
+                "clone": "1.0.4",
+                "clone-stats": "0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -13299,12 +12793,12 @@
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.3.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^2.0.0",
-                "vinyl": "^1.1.0"
+                "graceful-fs": "4.1.15",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "2.0.0",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "pify": {
@@ -13319,8 +12813,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -13332,14 +12826,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "defaults": "1.0.3",
+                "glob-stream": "3.1.18",
+                "glob-watcher": "0.0.6",
+                "graceful-fs": "3.0.11",
+                "mkdirp": "0.5.1",
+                "strip-bom": "1.0.0",
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -13354,7 +12848,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "^1.1.0"
+                        "natives": "1.1.6"
                     }
                 },
                 "isarray": {
@@ -13369,10 +12863,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -13387,8 +12881,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
+                        "first-chunk-stream": "1.0.0",
+                        "is-utf8": "0.2.1"
                     }
                 },
                 "through2": {
@@ -13397,8 +12891,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 },
                 "vinyl": {
@@ -13407,8 +12901,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -13419,8 +12913,8 @@
             "integrity": "sha1-84pa+53R6Ttl1VBGmsYYKsT1S44=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^2.1.0"
+                "through2": "2.0.5",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -13447,12 +12941,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -13463,7 +12957,7 @@
             "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.1"
+                "source-map": "0.5.7"
             }
         },
         "vm-browserify": {
@@ -13480,7 +12974,7 @@
             "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
             "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "watchpack": {
@@ -13489,9 +12983,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "chokidar": "2.0.4",
+                "graceful-fs": "4.1.15",
+                "neo-async": "2.6.0"
             }
         },
         "wcwidth": {
@@ -13500,7 +12994,7 @@
             "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.3"
+                "defaults": "1.0.3"
             }
         },
         "webpack": {
@@ -13513,26 +13007,26 @@
                 "@webassemblyjs/helper-module-context": "1.7.11",
                 "@webassemblyjs/wasm-edit": "1.7.11",
                 "@webassemblyjs/wasm-parser": "1.7.11",
-                "acorn": "^5.6.2",
-                "acorn-dynamic-import": "^3.0.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chrome-trace-event": "^1.0.0",
-                "enhanced-resolve": "^4.1.0",
-                "eslint-scope": "^4.0.0",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "micromatch": "^3.1.8",
-                "mkdirp": "~0.5.0",
-                "neo-async": "^2.5.0",
-                "node-libs-browser": "^2.0.0",
-                "schema-utils": "^0.4.4",
-                "tapable": "^1.1.0",
-                "uglifyjs-webpack-plugin": "^1.2.4",
-                "watchpack": "^1.5.0",
-                "webpack-sources": "^1.3.0"
+                "acorn": "5.7.3",
+                "acorn-dynamic-import": "3.0.0",
+                "ajv": "6.5.5",
+                "ajv-keywords": "3.2.0",
+                "chrome-trace-event": "1.0.0",
+                "enhanced-resolve": "4.1.0",
+                "eslint-scope": "4.0.0",
+                "json-parse-better-errors": "1.0.2",
+                "loader-runner": "2.3.1",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.6.0",
+                "node-libs-browser": "2.1.0",
+                "schema-utils": "0.4.7",
+                "tapable": "1.1.0",
+                "uglifyjs-webpack-plugin": "1.3.0",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.3.0"
             }
         },
         "webpack-dev-middleware": {
@@ -13541,10 +13035,10 @@
             "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
             "dev": true,
             "requires": {
-                "memory-fs": "~0.4.1",
-                "mime": "^2.3.1",
-                "range-parser": "^1.0.3",
-                "webpack-log": "^2.0.0"
+                "memory-fs": "0.4.1",
+                "mime": "2.3.1",
+                "range-parser": "1.2.0",
+                "webpack-log": "2.0.0"
             },
             "dependencies": {
                 "mime": {
@@ -13568,9 +13062,9 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "html-entities": "^1.2.0",
-                "querystring": "^0.2.0",
-                "strip-ansi": "^3.0.0"
+                "html-entities": "1.2.1",
+                "querystring": "0.2.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "webpack-log": {
@@ -13579,8 +13073,8 @@
             "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
             "dev": true,
             "requires": {
-                "ansi-colors": "^3.0.0",
-                "uuid": "^3.3.2"
+                "ansi-colors": "3.2.1",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "ansi-colors": {
@@ -13597,8 +13091,8 @@
             "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
             "dev": true,
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -13625,7 +13119,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -13640,7 +13134,7 @@
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2 || 2"
+                "string-width": "1.0.2"
             }
         },
         "widest-line": {
@@ -13649,7 +13143,7 @@
             "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13670,8 +13164,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -13680,7 +13174,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -13696,13 +13190,13 @@
             "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
             "dev": true,
             "requires": {
-                "async": "~1.0.0",
-                "colors": "1.0.x",
-                "cycle": "1.0.x",
-                "eyes": "0.1.x",
-                "isstream": "0.1.x",
-                "pkginfo": "0.3.x",
-                "stack-trace": "0.0.x"
+                "async": "1.0.0",
+                "colors": "1.0.3",
+                "cycle": "1.0.3",
+                "eyes": "0.1.8",
+                "isstream": "0.1.2",
+                "pkginfo": "0.3.1",
+                "stack-trace": "0.0.10"
             },
             "dependencies": {
                 "async": {
@@ -13737,7 +13231,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             }
         },
         "wrap-ansi": {
@@ -13745,8 +13239,8 @@
             "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             }
         },
         "wrappy": {
@@ -13754,24 +13248,15 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
-        "write": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-            "dev": true,
-            "requires": {
-                "mkdirp": "^0.5.1"
-            }
-        },
         "write-file-atomic": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.1.15",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
             }
         },
         "ws": {
@@ -13779,9 +13264,9 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
             "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.2",
+                "ultron": "1.1.1"
             }
         },
         "xdg-basedir": {
@@ -13817,7 +13302,7 @@
             "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.3.tgz",
             "integrity": "sha512-LTpz3jXPLUphMMmyufoZRSKnqMj41OVypZ8uYGzvjkMV9C1EdACrhQl/EM8Qfh5htSAuMIQFOejmKAZGkJfaCg==",
             "requires": {
-                "commander": "^2.9.0",
+                "commander": "2.19.0",
                 "cssfilter": "0.0.10"
             }
         },
@@ -13842,18 +13327,18 @@
             "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^2.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^10.1.0"
+                "cliui": "4.1.0",
+                "decamelize": "2.0.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "1.0.3",
+                "os-locale": "3.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "10.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13874,9 +13359,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
                     }
                 },
                 "execa": {
@@ -13885,13 +13370,13 @@
                     "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     }
                 },
                 "find-up": {
@@ -13900,7 +13385,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "3.0.0"
                     }
                 },
                 "get-stream": {
@@ -13927,7 +13412,7 @@
                     "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^2.0.0"
+                        "invert-kv": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -13936,8 +13421,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "os-locale": {
@@ -13946,9 +13431,9 @@
                     "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
                     "dev": true,
                     "requires": {
-                        "execa": "^0.10.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
+                        "execa": "0.10.0",
+                        "lcid": "2.0.0",
+                        "mem": "4.0.0"
                     }
                 },
                 "p-limit": {
@@ -13957,7 +13442,7 @@
                     "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^2.0.0"
+                        "p-try": "2.0.0"
                     }
                 },
                 "p-locate": {
@@ -13966,7 +13451,7 @@
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "2.0.0"
                     }
                 },
                 "p-try": {
@@ -13981,8 +13466,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -13991,7 +13476,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "which-module": {
@@ -14006,7 +13491,7 @@
                     "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -14016,8 +13501,8 @@
             "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
             "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
             "requires": {
-                "camelcase": "^3.0.0",
-                "lodash.assign": "^4.0.6"
+                "camelcase": "3.0.0",
+                "lodash.assign": "4.2.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -14033,8 +13518,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.1.0"
             }
         },
         "yeast": {
@@ -14049,9 +13534,9 @@
             "integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
             "dev": true,
             "requires": {
-                "archiver-utils": "^2.0.0",
-                "compress-commons": "^1.2.0",
-                "readable-stream": "^2.0.0"
+                "archiver-utils": "2.0.0",
+                "compress-commons": "1.2.2",
+                "readable-stream": "2.3.6"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
         "husky": "^0.14.3",
         "ignore-loader": "^0.1.2",
         "lint-staged": "^7.2.0",
+        "node-sass-tilde-importer": "^1.0.2",
         "nodemon": "^1.18.7",
         "ora": "^3.0.0",
         "readdir-recursive": "0.0.4",


### PR DESCRIPTION
Update the gulp task to allow for tilde based sass imports to work
Now allows ~node_modules in addition to node-modules as base for sass import
Correct an error in documentation where actionTypes should come from deps  no import.