### PR TITLE
Sortable Express Middleware

### DIFF
--- a/.core/index.js
+++ b/.core/index.js
@@ -8,7 +8,7 @@ import bodyParser from 'body-parser';
 import router from './server/router';
 import cookieParser from 'cookie-parser';
 import cookieSession from 'cookie-session';
-import proxy from 'express-http-proxy';
+import proxy from 'http-proxy-middleware';
 import morgan from 'morgan';
 import apiConfig from 'appdir/api/config';
 import path from 'path';
@@ -65,6 +65,7 @@ const adminURL = process.env.ACTINIUM_ADMIN_URL || false;
 // set app variables
 app.set('x-powered-by', false);
 
+// express middlewares
 let middlewares = [
     process.env.DEBUG === 'on'
         ? {
@@ -82,19 +83,15 @@ let middlewares = [
     },
     {
         name: 'api',
-        use: [
-            ['/api', '/api/*'],
-            proxy(`${restAPI}`, {
-                proxyReqOptDecorator: req => {
-                    req.headers['x-forwarded-host'] = `localhost:${port}`;
-                    return req;
-                },
-                proxyReqPathResolver: req => {
-                    const resolvedPath = `${restAPI}${req.url}`;
-                    return resolvedPath;
-                },
-            }),
-        ],
+        use: proxy('/api', {
+            target: restAPI,
+            changeOrigin: true,
+            pathRewrite: {
+                '^/api': '',
+            },
+            logLevel: process.env.DEBUG === 'on' ? 'debug' : 'error',
+            ws: true,
+        }),
     },
     // parsers
     {
@@ -173,12 +170,13 @@ middlewares.push({
 // Give app an opportunity to change middlewares
 if (fs.existsSync(`${rootPath}/src/app/server/middleware.js`)) {
     middlewares = require(`${rootPath}/src/app/server/middleware.js`)(
-        middlewares
+        middlewares,
     );
 }
 
 middlewares
     .filter(_ => _)
+    .sort(({ order: aOrder = 0 }, { oder: bOrder = 0 }) => bOrder - aOrder)
     .forEach(({ use }) => {
         if (Array.isArray(use)) {
             app.use(...use);

--- a/.core/index.js
+++ b/.core/index.js
@@ -176,7 +176,7 @@ if (fs.existsSync(`${rootPath}/src/app/server/middleware.js`)) {
 
 middlewares
     .filter(_ => _)
-    .sort(({ order: aOrder = 0 }, { oder: bOrder = 0 }) => bOrder - aOrder)
+    .sort(({ order: aOrder = 0 }, { order: bOrder = 0 }) => bOrder - aOrder)
     .forEach(({ use }) => {
         if (Array.isArray(use)) {
             app.use(...use);

--- a/.core/manifest/manifest-tools.js
+++ b/.core/manifest/manifest-tools.js
@@ -41,8 +41,8 @@ const find = (searches = [], sourceMappings) => {
         mappings = jsSources(sourceMapping.from)
             .map(file => file.path)
             .reduce((mappings, file) => {
-                searches.forEach(({ name, pattern }) => {
-                    if (pattern.test(file)) {
+                searches.forEach(({ name, pattern, ignore }) => {
+                    if (pattern.test(file) && (!ignore || !ignore.test(file))) {
                         mappings[name].imports.push(
                             file
                                 .replace(/\\/g, '/')

--- a/.core/reactium-config.js
+++ b/.core/reactium-config.js
@@ -3,7 +3,7 @@
  * @type {Object}
  */
 module.exports = {
-    version: '2.4.2',
+    version: '2.4.4',
     semver: '^2.0.0',
     update: {
         package: {
@@ -57,6 +57,7 @@ module.exports = {
                     '@babel/node': '^7.0.0',
                     '@babel/polyfill': '^7.0.0',
                     gsap: '^2.0.2',
+                    'http-proxy-middleware': '^0.19.1',
                     prettier: '^1.15.1',
                     'react-frame-component': '^4.0.1',
                     'redbox-react': '^1.6.0',
@@ -65,7 +66,7 @@ module.exports = {
                     'run-script-os': '^1.0.5',
                     xss: '^1.0.3',
                 },
-                remove: ['beautify'],
+                remove: ['beautify', 'express-http-proxy'],
             },
             scripts: {
                 add: {
@@ -132,6 +133,7 @@ module.exports = {
                 name: 'allMiddleware',
                 type: 'middleware',
                 pattern: /middleware.jsx?$/,
+                ignore: /server\/middleware/,
             },
             {
                 name: 'allEnhancers',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "reactium",
-    "version": "2.4.1",
+    "version": "2.4.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -5265,11 +5265,6 @@
                 "es6-symbol": "^3.1.1"
             }
         },
-        "es6-promise": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
-        },
         "es6-symbol": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
@@ -5702,31 +5697,6 @@
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
                     "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-                }
-            }
-        },
-        "express-http-proxy": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.5.0.tgz",
-            "integrity": "sha512-rYXjOj+ldSDZdmCxRDX/7o6Oxtz45sS9l4QTsvqm+ZFxqI5xTA4usMMP4FBrrKTpDPuQkI2YVda+0LvkJhPu7A==",
-            "requires": {
-                "debug": "^3.0.1",
-                "es6-promise": "^4.1.1",
-                "raw-body": "^2.3.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 }
             }
         },
@@ -8271,6 +8241,34 @@
             "requires": {
                 "eventemitter3": "1.x.x",
                 "requires-port": "1.x.x"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+            "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+            "requires": {
+                "http-proxy": "^1.17.0",
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.11",
+                "micromatch": "^3.1.10"
+            },
+            "dependencies": {
+                "eventemitter3": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+                    "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+                },
+                "http-proxy": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+                    "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+                    "requires": {
+                        "eventemitter3": "^3.0.0",
+                        "follow-redirects": "^1.0.0",
+                        "requires-port": "^1.0.0"
+                    }
+                }
             }
         },
         "http-signature": {
@@ -13965,8 +13963,7 @@
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-            "dev": true
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "reselect": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reactium",
-    "version": "2.4.3",
+    "version": "2.4.4",
     "description": "A framework for creating React + Redux apps using the domain driven design (DDD) paradigm.",
     "main": "index.js",
     "scripts": {
@@ -63,11 +63,11 @@
         "directory-tree": "^2.0.0",
         "eslint": "^5.12.0",
         "express": "^4.16.2",
-        "express-http-proxy": "^1.1.0",
         "globby": "^8.0.1",
         "gsap": "^2.0.2",
         "htmltojsx": "^0.3.0",
         "http-auth": "^3.2.3",
+        "http-proxy-middleware": "^0.19.1",
         "js-beautify": "^1.7.5",
         "marked": "^0.4.0",
         "moment": "^2.20.1",


### PR DESCRIPTION
Updated express middleware proxy from express-http-proxy to simpler http-proxy-middleware.
Make express middleware sortable.
Remove false middleware artifact from manifest when using server middleware.
Add optional ignore pattern to manifest tools.