### PR TITLE
Added ability to set a browserSync startPath when developing locally.

### DIFF
--- a/.core/gulp.config.js
+++ b/.core/gulp.config.js
@@ -91,6 +91,7 @@ const defaultConfig = {
         library: 'lib',
         build: 'build/src',
         colors: 'src/assets/style/_scss/_colors.scss',
+        startPath: '/',
     },
 };
 

--- a/.core/gulp.tasks.js
+++ b/.core/gulp.tasks.js
@@ -102,6 +102,7 @@ const reactium = (gulp, config, webpackConfig) => {
                 proxy: `localhost:${config.port.proxy}`,
                 open: open,
                 ghostMode: false,
+                startPath: config.dest.startPath,
             });
 
             done();


### PR DESCRIPTION
By setting the gulp.config > dest.startPath value to a route like: `/toolkit` browserSync will immediately navigate to that page when it starts up. 