### PR TITLE
Worked a Zone in as the Provider children named: 'reactium-provider'.

### DIFF
--- a/.core/app/index.js
+++ b/.core/app/index.js
@@ -191,7 +191,7 @@ export const App = async () => {
 
             ReactDOM[ssr ? 'hydrate' : 'render'](
                 <Provider store={store}>
-                    <Zone zone='reactium-provider-before' />
+                    <Zone zone='reactium-provider' />
                     <Router history={Reactium.Routing.history} />
                     <Zone zone='reactium-provider-after' />
                 </Provider>,

--- a/.core/app/index.js
+++ b/.core/app/index.js
@@ -189,16 +189,11 @@ export const App = async () => {
             );
             console.log(...message);
 
-            Reactium.Zone.addComponent({
-                id: 'REACTIUM_ROUTER',
-                zone: 'reactium-provider',
-                order: Reactium.Enums.priority.neutral,
-                component: () => <Router history={Reactium.Routing.history} />,
-            });
-
             ReactDOM[ssr ? 'hydrate' : 'render'](
                 <Provider store={store}>
-                    <Zone zone='reactium-provider' />
+                    <Zone zone='reactium-provider-before' />
+                    <Router history={Reactium.Routing.history} />
+                    <Zone zone='reactium-provider-after' />
                 </Provider>,
                 appElement,
             );

--- a/.core/app/index.js
+++ b/.core/app/index.js
@@ -4,11 +4,11 @@
  * -----------------------------------------------------------------------------
  */
 import React from 'react';
+import ReactDOM from 'react-dom';
 import _ from 'underscore';
 import op from 'object-path';
 import deps from 'dependencies';
-import ReactDOM from 'react-dom';
-import { Zone } from 'reactium-core/sdk';
+import 'externals';
 
 /**
  * -----------------------------------------------------------------------------
@@ -23,6 +23,7 @@ export const App = async () => {
         default: Reactium,
         useHookComponent,
         isBrowserWindow,
+        Zone,
     } = await import('reactium-core/sdk');
 
     console.log('Initializing Application Hooks');

--- a/.core/app/index.js
+++ b/.core/app/index.js
@@ -4,11 +4,11 @@
  * -----------------------------------------------------------------------------
  */
 import React from 'react';
-import ReactDOM from 'react-dom';
 import _ from 'underscore';
 import op from 'object-path';
 import deps from 'dependencies';
-import 'externals';
+import ReactDOM from 'react-dom';
+import { Zone } from 'reactium-core/sdk';
 
 /**
  * -----------------------------------------------------------------------------
@@ -189,9 +189,16 @@ export const App = async () => {
             );
             console.log(...message);
 
+            Reactium.Zone.addComponent({
+                id: 'REACTIUM_ROUTER',
+                zone: 'reactium-provider',
+                order: Reactium.Enums.priority.neutral,
+                component: () => <Router history={Reactium.Routing.history} />,
+            });
+
             ReactDOM[ssr ? 'hydrate' : 'render'](
                 <Provider store={store}>
-                    <Router history={Reactium.Routing.history} />
+                    <Zone zone='reactium-provider' />
                 </Provider>,
                 appElement,
             );

--- a/.core/server/renderer/ssr.js
+++ b/.core/server/renderer/ssr.js
@@ -7,6 +7,7 @@ import op from 'object-path';
 import { matchRoutes } from 'react-router-config';
 import 'reactium-core/redux/storeCreator';
 import Router from 'reactium-core/components/Router/server';
+import { Zone } from 'reactium-core/sdk';
 
 const app = {};
 app.dependencies = global.dependencies;
@@ -63,12 +64,14 @@ const renderer = async (req, res, context) => {
 
     const content = renderToString(
         <Provider store={store}>
+            <Zone zone='reactium-provider-before' />
             <Router
                 server={true}
                 location={req.originalUrl}
                 context={context}
                 routes={routes}
             />
+            <Zone zone='reactium-provider-after' />
         </Provider>,
     );
 

--- a/.core/server/renderer/ssr.js
+++ b/.core/server/renderer/ssr.js
@@ -64,7 +64,7 @@ const renderer = async (req, res, context) => {
 
     const content = renderToString(
         <Provider store={store}>
-            <Zone zone='reactium-provider-before' />
+            <Zone zone='reactium-provider' />
             <Router
                 server={true}
                 location={req.originalUrl}


### PR DESCRIPTION
The thought behind this is that you could add a component to the `<Provider />` that would essentially be persistent in the app. Now imagine you add a component to the `<Provider />` with a `useSyncState()` object that registers a handle via `useRegisterHandle()`, instant app state w/o Redux. 

**/src/app/AppState/index.js**
```
import { useSyncState, useRegisterHandle } from 'reactium-core/sdk';

export default () => {
  const state = useSyncState({});
  useRegisterHandle('AppState', () => state);
  return null;
};

```

**/src/app/AppState/reactium-hooks.js**

```
import State from '.';
import Reactium from 'reactium-core/sdk';

Reactium.Zone.addComponent({
  id: 'APP_STATE',
  zone: 'reactium-provider',
  component: State,
  order: Reactium.Enums.priority.highest,
});
```

**/src/app/SomeWildComponent/index.js**

```
const SomeWildComponent = () => {
  const state = useHandle('AppState');
  
  const onClick = () => {
     state.dispatchEvent(new Event('some-wild-component-click'));
  };
  
  return <button onClick={onClick}>Some Wild Button</button>;
}
```

There are other applicable use cases, but this was my most reoccurring one. 
