### PR TITLE
Fix windows build of reactium-api.

### DIFF
--- a/.core/gulp.config.js
+++ b/.core/gulp.config.js
@@ -142,7 +142,6 @@ const defaultConfig = {
         'umdLibraries',
         'serviceWorker',
         'compress',
-        'apidocs',
         'postBuild',
     ],
 };

--- a/.core/webpack.config.js
+++ b/.core/webpack.config.js
@@ -141,6 +141,7 @@ module.exports = config => {
     sdk.addIgnore('reactium-gulp', /reactium-gulp.js$/);
     sdk.addIgnore('reactium-webpack', /reactium-webpack.js$/);
     sdk.addIgnore('parse-node', /parse\/node/);
+    sdk.addIgnore('xmlhttprequest', /xmlhttprequest/);
 
     if (env === 'production') {
         sdk.addIgnore('redux-devtools', /redux-devtools/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,8 +495,8 @@
         "@atomic-reactor/reactium-api": {
             "version": "file:reactium_modules/@atomic-reactor/reactium-api/_npm",
             "requires": {
-                "parse": "^2.17.0",
-                "socket.io-client": "^3.1.0"
+                "parse": "^3.4.0",
+                "socket.io-client": "^4.4.0"
             }
         },
         "@atomic-reactor/reactium-capability": {
@@ -8988,14 +8988,6 @@
             "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
             "dev": true
         },
-        "filelist": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-            "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
-            "requires": {
-                "minimatch": "^3.0.4"
-            }
-        },
         "filereader": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
@@ -12335,7 +12327,6 @@
             "requires": {
                 "async": "0.9.x",
                 "chalk": "^2.4.2",
-                "filelist": "^1.0.1",
                 "minimatch": "^3.0.4"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     ]
   },
   "reactiumDependencies": {
-    "@atomic-reactor/reactium-api": "2.0.0",
+    "@atomic-reactor/reactium-api": "2.0.3",
     "@atomic-reactor/reactium-capability": "2.0.0",
     "@atomic-reactor/reactium-demo": "1.0.1",
     "@atomic-reactor/reactium-role": "2.0.0",


### PR DESCRIPTION
Prevent xmlhttprequest from being bundled for browser.  @atomic-reactor/reactium-api@2.0.3 to fix windows build for socket.io client. (using distribution UMD bundle instead)