### PR TITLE
Bugfix/partials sorting

### DIFF
--- a/.core/gulp.tasks.js
+++ b/.core/gulp.tasks.js
@@ -672,10 +672,13 @@ $assets: (
                     return partial.replace('reactium_modules/', '+');
                 }
 
-                return path.relative(
-                    path.dirname(config.dest.modulesPartial),
-                    path.resolve(rootPath, partial),
-                );
+                return path
+                    .relative(
+                        path.dirname(config.dest.modulesPartial),
+                        path.resolve(rootPath, partial),
+                    )
+                    .split(/[\\\/]/g)
+                    .join(path.posix.sep);
             })
             .map(partial => partial.replace(/\.scss$/, ''))
             .sort((a, b) => {

--- a/.core/gulp.tasks.js
+++ b/.core/gulp.tasks.js
@@ -681,6 +681,27 @@ $assets: (
                     .join(path.posix.sep);
             })
             .map(partial => partial.replace(/\.scss$/, ''))
+            // sort by directory basename
+            .sort((a, b) => {
+                const aBase = path
+                    .basename(path.dirname(a))
+                    .toLocaleLowerCase();
+                const bBase = path
+                    .basename(path.dirname(b))
+                    .toLocaleLowerCase();
+                if (aBase > bBase) return 1;
+                if (aBase < bBase) return -1;
+                return 0;
+            })
+            // sort by file basename
+            .sort((a, b) => {
+                const aBase = path.basename(a).toLocaleLowerCase();
+                const bBase = path.basename(b).toLocaleLowerCase();
+                if (aBase > bBase) return 1;
+                if (aBase < bBase) return -1;
+                return 0;
+            })
+            // sort by priority
             .sort((a, b) => {
                 const aMatch =
                     SassPartialRegistry.list.find(({ pattern }) =>


### PR DESCRIPTION
Instead of default glob sort with entire path, presort for basedir and filename before priority. This way partials won't load first after priority simple for being higher in the directory tree.