### PR TITLE
Replaceable Shell Loader component.

### DIFF
--- a/.core/app/shell.js
+++ b/.core/app/shell.js
@@ -1,8 +1,14 @@
-export const Shell = async () => {
+export const Shell = async LoadingComponent => {
     const { default: React, useRef } = await import('react');
     const { default: _ } = await import('underscore');
     const { createRoot } = await import('react-dom/client');
-    const { Loading } = await import('../components/Loading');
+
+    let Loading;
+    if (LoadingComponent) Loading = LoadingComponent;
+    else {
+        const mod = await import('../components/Loading');
+        Loading = mod.Loading;
+    }
 
     const Shell = () => {
         window.LoadingRef = useRef();
@@ -16,5 +22,10 @@ export const Shell = async () => {
     const { App } = await import('./index');
     await App();
 
-    _.defer(() => window.LoadingRef.current.setVisible(false));
+    _.defer(
+        () =>
+            window.LoadingRef.current &&
+            _.isFunction(window.LoadingRef.current.setVisible) &&
+            window.LoadingRef.current.setVisible(false),
+    );
 };


### PR DESCRIPTION
Make it a simple matter to replace the core Loader component entirely from src/app/main.js without necessarily adding additional bundle size to the shell.