### PR TITLE
Embedded Style Asset Partials

### DIFF
--- a/.core/gulp.config.js
+++ b/.core/gulp.config.js
@@ -27,7 +27,10 @@ const defaultConfig = {
         js: ['src/app/**/*', 'reactium_modules/**/*'],
         markup: ['src/**/*.html', 'src/**/*.css', 'reactium_modules/**/*.css'],
         colors: ['src/**/*/colors.json'],
-        pluginAssets: ['src/app/**/plugin-assets.json'],
+        pluginAssets: [
+            'src/app/**/plugin-assets.json',
+            'src/app/**/style-assets.json',
+        ],
         restartWatches: [
             'src/**/assets/style/*.scss',
             '!src/**/assets/style/_*.scss',

--- a/.core/gulp.tasks.js
+++ b/.core/gulp.tasks.js
@@ -518,7 +518,7 @@ $assets: map.set($assets, "{{key}}", "{{{dataURL}}}");
                             fileName,
                         )} to partial at ${path.resolve(
                             base,
-                            '_plugin-assets.scss',
+                            '_reactium-style-variables.scss',
                         )}`,
                     );
                     const dataURL = await fileReader(
@@ -528,13 +528,13 @@ $assets: map.set($assets, "{{key}}", "{{{dataURL}}}");
                 }
 
                 fs.writeFileSync(
-                    path.resolve(base, '_plugin-assets.scss'),
+                    path.resolve(base, '_reactium-style-variables.scss'),
                     pluginAssetsTemplate(mappings),
                     'utf8',
                 );
             } catch (error) {
                 console.error(
-                    'error generating sass partial _plugin-assets.scss in ' +
+                    'error generating sass partial _reactium-style-variables.scss in ' +
                         base,
                     error,
                 );
@@ -792,8 +792,8 @@ $assets: map.set($assets, "{{key}}", "{{{dataURL}}}");
 
     const styles = gulp.series(
         task('styles:colors'),
-        task('styles:partials'),
         task('styles:pluginAssets'),
+        task('styles:partials'),
         task('styles:compile'),
     );
 


### PR DESCRIPTION
Look for style-assets.json in addition to plugin-assets.json (now deprecated), and output to _reactium-style-variables.scss instead of _plugin-assets.scss, so that it will automatically be available to other top-level stylesheets.